### PR TITLE
Implement schema-path parser and matcher with trie

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ func main() {
     // Test matches
     for _, path := range paths {
         segments := processor.ConvertPathToSegments(path)
-        if tree.MatchPath(segments) {
+        if tree.MatchSegments(segments) {
             value, _ := processor.ExtractValue(jsonData, path)
             fmt.Printf("Match: %s = %v\\n", path, value)
         }
@@ -226,7 +226,7 @@ err := tree.AddPattern(expr)
 
 // Match paths
 segments := processor.ConvertPathToSegments("$.node.child.value")
-matches := tree.MatchPath(segments)
+matches := tree.MatchSegments(segments)
 ```
 
 ## 📝 Path Expression Syntax

--- a/cmd/schemapath/main.go
+++ b/cmd/schemapath/main.go
@@ -1,39 +1,39 @@
 package main
 
 import (
-        "encoding/json"
-        "fmt"
-        "io/ioutil"
-        "os"
-        "strings"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
 
-        jsonpkg "jsonpath-sdk/json"
-        "jsonpath-sdk/parser"
-        "jsonpath-sdk/tree"
-        "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
+	jsonpkg "jsonpath-sdk/json"
+	"jsonpath-sdk/parser"
+	"jsonpath-sdk/tree"
 )
 
 const version = "1.0.0"
 
 var (
-        verbose     bool
-        quiet       bool
-        outputJSON  bool
-        prettyPrint bool
+	verbose     bool
+	quiet       bool
+	outputJSON  bool
+	prettyPrint bool
 )
 
 // logInfo prints info messages unless in JSON mode or quiet mode
 func logInfo(format string, args ...interface{}) {
-        if !outputJSON && !quiet {
-                fmt.Fprintf(os.Stderr, format, args...)
-        }
+	if !outputJSON && !quiet {
+		fmt.Fprintf(os.Stderr, format, args...)
+	}
 }
 
 var rootCmd = &cobra.Command{
-        Use:     "schemapath",
-        Version: version,
-        Short:   "A schema-path expression parser with recursive structure support",
-        Long: `A command-line utility for parsing and testing schema-path expressions
+	Use:     "schemapath",
+	Version: version,
+	Short:   "A schema-path expression parser with recursive structure support",
+	Long: `A command-line utility for parsing and testing schema-path expressions
 that support recursive JSON schema structures using group operators and repetition patterns.
 
 Features:
@@ -51,324 +51,324 @@ Examples:
 }
 
 var parseCmd = &cobra.Command{
-        Use:   "parse [expression]",
-        Short: "Parse a schema-path expression and display its structure",
-        Args:  cobra.ExactArgs(1),
-        Run: func(cmd *cobra.Command, args []string) {
-                expression := args[0]
-                
-                logInfo("Parsing expression: %s\n", expression)
-                
-                // Parse the expression using the parser
-                expr, err := parser.ParseExpression(expression)
-                if err != nil {
-                        fmt.Fprintf(os.Stderr, "Error parsing expression: %v\n", err)
-                        os.Exit(1)
-                }
-                
-                if outputJSON {
-                        // Output as JSON structure
-                        result := map[string]interface{}{
-                                "expression":    expression,
-                                "parsed":        expr.String(),
-                                "root":          expr.Root.String(),
-                                "segment_count": len(expr.Segments),
-                                "segments":      make([]string, len(expr.Segments)),
-                        }
-                        for i, segment := range expr.Segments {
-                                result["segments"].([]string)[i] = segment.String()
-                        }
-                        
-                        var output []byte
-                        if prettyPrint {
-                                output, _ = json.MarshalIndent(result, "", "  ")
-                        } else {
-                                output, _ = json.Marshal(result)
-                        }
-                        fmt.Println(string(output))
-                } else {
-                        // Display the parsed structure in human-readable format
-                        fmt.Printf("Parsed structure: %s\n", expr.String())
-                        fmt.Printf("Root: %s\n", expr.Root.String())
-                        fmt.Printf("Segments (%d):\n", len(expr.Segments))
-                        for i, segment := range expr.Segments {
-                                fmt.Printf("  [%d]: %s\n", i, segment.String())
-                        }
-                        
-                        if verbose {
-                                fmt.Printf("\nExpression validation: ✓ Valid\n")
-                        }
-                }
-        },
+	Use:   "parse [expression]",
+	Short: "Parse a schema-path expression and display its structure",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		expression := args[0]
+
+		logInfo("Parsing expression: %s\n", expression)
+
+		// Parse the expression using the parser
+		expr, err := parser.ParseExpression(expression)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing expression: %v\n", err)
+			os.Exit(1)
+		}
+
+		if outputJSON {
+			// Output as JSON structure
+			result := map[string]interface{}{
+				"expression":    expression,
+				"parsed":        expr.String(),
+				"root":          expr.Root.String(),
+				"segment_count": len(expr.Segments),
+				"segments":      make([]string, len(expr.Segments)),
+			}
+			for i, segment := range expr.Segments {
+				result["segments"].([]string)[i] = segment.String()
+			}
+
+			var output []byte
+			if prettyPrint {
+				output, _ = json.MarshalIndent(result, "", "  ")
+			} else {
+				output, _ = json.Marshal(result)
+			}
+			fmt.Println(string(output))
+		} else {
+			// Display the parsed structure in human-readable format
+			fmt.Printf("Parsed structure: %s\n", expr.String())
+			fmt.Printf("Root: %s\n", expr.Root.String())
+			fmt.Printf("Segments (%d):\n", len(expr.Segments))
+			for i, segment := range expr.Segments {
+				fmt.Printf("  [%d]: %s\n", i, segment.String())
+			}
+
+			if verbose {
+				fmt.Printf("\nExpression validation: ✓ Valid\n")
+			}
+		}
+	},
 }
 
 var testCmd = &cobra.Command{
-        Use:   "test [expression] [json]",
-        Short: "Test if a schema-path expression matches the given JSON data",
-        Args:  cobra.ExactArgs(2),
-        Run: func(cmd *cobra.Command, args []string) {
-                expression := args[0]
-                jsonData := args[1]
-                
-                if !quiet {
-                        fmt.Printf("Testing expression: %s\n", expression)
-                }
-                
-                // Handle file input
-                if strings.HasPrefix(jsonData, "@") {
-                        filename := jsonData[1:]
-                        data, err := ioutil.ReadFile(filename)
-                        if err != nil {
-                                fmt.Fprintf(os.Stderr, "Error reading file %s: %v\n", filename, err)
-                                os.Exit(1)
-                        }
-                        jsonData = string(data)
-                }
-                
-                // Validate and format JSON
-                processor := jsonpkg.NewPathExtractor()
-                if err := processor.ValidateJSON(jsonData); err != nil {
-                        fmt.Fprintf(os.Stderr, "Error: Invalid JSON data: %v\n", err)
-                        os.Exit(1)
-                }
-                
-                if verbose {
-                        fmt.Printf("JSON data is valid\n")
-                }
-                
-                // Parse the expression
-                expr, err := parser.ParseExpression(expression)
-                if err != nil {
-                        fmt.Fprintf(os.Stderr, "Error parsing expression: %v\n", err)
-                        os.Exit(1)
-                }
-                
-                // Build pattern tree
-                patternTree := tree.NewPatternTree()
-                if err := patternTree.AddPattern(expr); err != nil {
-                        fmt.Fprintf(os.Stderr, "Error building pattern tree: %v\n", err)
-                        os.Exit(1)
-                }
-                
-                // Extract all paths from JSON
-                paths, err := processor.ExtractPaths(jsonData)
-                if err != nil {
-                        fmt.Fprintf(os.Stderr, "Error extracting paths: %v\n", err)
-                        os.Exit(1)
-                }
-                
-                matchCount := 0
-                matchingPaths := []string{}
-                
-                for _, path := range paths {
-                        segments := processor.ConvertPathToSegments(path)
-                        matches := patternTree.MatchPath(segments)
-                        
-                        if matches {
-                                matchCount++
-                                matchingPaths = append(matchingPaths, path)
-                                if verbose || !quiet {
-                                        fmt.Printf("  ✓ %s (matches)\n", path)
-                                }
-                        } else if verbose {
-                                fmt.Printf("  ✗ %s\n", path)
-                        }
-                }
-                
-                if outputJSON {
-                        result := map[string]interface{}{
-                                "expression":     expression,
-                                "total_paths":    len(paths),
-                                "matching_paths": matchCount,
-                                "matches":        matchingPaths,
-                                "success":        matchCount > 0,
-                        }
-                        if verbose {
-                                result["all_paths"] = paths
-                        }
-                        
-                        var output []byte
-                        if prettyPrint {
-                                output, _ = json.MarshalIndent(result, "", "  ")
-                        } else {
-                                output, _ = json.Marshal(result)
-                        }
-                        fmt.Println(string(output))
-                } else {
-                        if !quiet {
-                                fmt.Printf("\nFound %d paths in JSON:\n", len(paths))
-                        }
-                        
-                        if !quiet {
-                                fmt.Printf("\nResult: %d out of %d paths match the expression\n", matchCount, len(paths))
-                                if matchCount > 0 {
-                                        fmt.Printf("✓ Expression matches JSON data\n")
-                                } else {
-                                        fmt.Printf("✗ Expression does not match JSON data\n")
-                                }
-                        }
-                }
-                
-                // Set exit code based on match result for scripting
-                if matchCount == 0 {
-                        os.Exit(1)
-                }
-        },
+	Use:   "test [expression] [json]",
+	Short: "Test if a schema-path expression matches the given JSON data",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		expression := args[0]
+		jsonData := args[1]
+
+		if !quiet {
+			fmt.Printf("Testing expression: %s\n", expression)
+		}
+
+		// Handle file input
+		if strings.HasPrefix(jsonData, "@") {
+			filename := jsonData[1:]
+			data, err := ioutil.ReadFile(filename)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error reading file %s: %v\n", filename, err)
+				os.Exit(1)
+			}
+			jsonData = string(data)
+		}
+
+		// Validate and format JSON
+		processor := jsonpkg.NewPathExtractor()
+		if err := processor.ValidateJSON(jsonData); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: Invalid JSON data: %v\n", err)
+			os.Exit(1)
+		}
+
+		if verbose {
+			fmt.Printf("JSON data is valid\n")
+		}
+
+		// Parse the expression
+		expr, err := parser.ParseExpression(expression)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing expression: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Build pattern tree
+		patternTree := tree.NewPatternTree()
+		if err := patternTree.AddPattern(expr); err != nil {
+			fmt.Fprintf(os.Stderr, "Error building pattern tree: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Extract all paths from JSON
+		paths, err := processor.ExtractPaths(jsonData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error extracting paths: %v\n", err)
+			os.Exit(1)
+		}
+
+		matchCount := 0
+		matchingPaths := []string{}
+
+		for _, path := range paths {
+			segments := processor.ConvertPathToSegments(path)
+			matches := patternTree.MatchSegments(segments)
+
+			if matches {
+				matchCount++
+				matchingPaths = append(matchingPaths, path)
+				if verbose || !quiet {
+					fmt.Printf("  ✓ %s (matches)\n", path)
+				}
+			} else if verbose {
+				fmt.Printf("  ✗ %s\n", path)
+			}
+		}
+
+		if outputJSON {
+			result := map[string]interface{}{
+				"expression":     expression,
+				"total_paths":    len(paths),
+				"matching_paths": matchCount,
+				"matches":        matchingPaths,
+				"success":        matchCount > 0,
+			}
+			if verbose {
+				result["all_paths"] = paths
+			}
+
+			var output []byte
+			if prettyPrint {
+				output, _ = json.MarshalIndent(result, "", "  ")
+			} else {
+				output, _ = json.Marshal(result)
+			}
+			fmt.Println(string(output))
+		} else {
+			if !quiet {
+				fmt.Printf("\nFound %d paths in JSON:\n", len(paths))
+			}
+
+			if !quiet {
+				fmt.Printf("\nResult: %d out of %d paths match the expression\n", matchCount, len(paths))
+				if matchCount > 0 {
+					fmt.Printf("✓ Expression matches JSON data\n")
+				} else {
+					fmt.Printf("✗ Expression does not match JSON data\n")
+				}
+			}
+		}
+
+		// Set exit code based on match result for scripting
+		if matchCount == 0 {
+			os.Exit(1)
+		}
+	},
 }
 
 var validateCmd = &cobra.Command{
-        Use:   "validate [json]",
-        Short: "Validate JSON data format",
-        Args:  cobra.ExactArgs(1),
-        Run: func(cmd *cobra.Command, args []string) {
-                jsonData := args[0]
-                
-                // Handle file input
-                if strings.HasPrefix(jsonData, "@") {
-                        filename := jsonData[1:]
-                        data, err := ioutil.ReadFile(filename)
-                        if err != nil {
-                                fmt.Fprintf(os.Stderr, "Error reading file %s: %v\n", filename, err)
-                                os.Exit(1)
-                        }
-                        jsonData = string(data)
-                }
-                
-                processor := jsonpkg.NewPathExtractor()
-                if err := processor.ValidateJSON(jsonData); err != nil {
-                        if !quiet {
-                                fmt.Fprintf(os.Stderr, "Invalid JSON: %v\n", err)
-                        }
-                        os.Exit(1)
-                }
-                
-                if !quiet {
-                        fmt.Println("✓ JSON is valid")
-                }
-                
-                if verbose {
-                        // Show formatted JSON
-                        formatted, err := processor.FormatJSON(jsonData)
-                        if err == nil {
-                                fmt.Printf("\nFormatted JSON:\n%s\n", formatted)
-                        }
-                }
-        },
+	Use:   "validate [json]",
+	Short: "Validate JSON data format",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonData := args[0]
+
+		// Handle file input
+		if strings.HasPrefix(jsonData, "@") {
+			filename := jsonData[1:]
+			data, err := ioutil.ReadFile(filename)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error reading file %s: %v\n", filename, err)
+				os.Exit(1)
+			}
+			jsonData = string(data)
+		}
+
+		processor := jsonpkg.NewPathExtractor()
+		if err := processor.ValidateJSON(jsonData); err != nil {
+			if !quiet {
+				fmt.Fprintf(os.Stderr, "Invalid JSON: %v\n", err)
+			}
+			os.Exit(1)
+		}
+
+		if !quiet {
+			fmt.Println("✓ JSON is valid")
+		}
+
+		if verbose {
+			// Show formatted JSON
+			formatted, err := processor.FormatJSON(jsonData)
+			if err == nil {
+				fmt.Printf("\nFormatted JSON:\n%s\n", formatted)
+			}
+		}
+	},
 }
 
 var extractCmd = &cobra.Command{
-        Use:   "extract [expression] [json_file]",
-        Short: "Extract values from JSON data using schema-path expression",
-        Args:  cobra.ExactArgs(2),
-        Run: func(cmd *cobra.Command, args []string) {
-                expression := args[0]
-                filename := args[1]
-                
-                // Read JSON file
-                data, err := ioutil.ReadFile(filename)
-                if err != nil {
-                        fmt.Fprintf(os.Stderr, "Error reading file %s: %v\n", filename, err)
-                        os.Exit(1)
-                }
-                jsonData := string(data)
-                
-                processor := jsonpkg.NewPathExtractor()
-                if err := processor.ValidateJSON(jsonData); err != nil {
-                        fmt.Fprintf(os.Stderr, "Invalid JSON in file %s: %v\n", filename, err)
-                        os.Exit(1)
-                }
-                
-                // Parse the expression
-                expr, err := parser.ParseExpression(expression)
-                if err != nil {
-                        fmt.Fprintf(os.Stderr, "Error parsing expression: %v\n", err)
-                        os.Exit(1)
-                }
-                
-                // Build pattern tree and extract matching paths
-                patternTree := tree.NewPatternTree()
-                if err := patternTree.AddPattern(expr); err != nil {
-                        fmt.Fprintf(os.Stderr, "Error building pattern tree: %v\n", err)
-                        os.Exit(1)
-                }
-                
-                paths, err := processor.ExtractPaths(jsonData)
-                if err != nil {
-                        fmt.Fprintf(os.Stderr, "Error extracting paths: %v\n", err)
-                        os.Exit(1)
-                }
-                
-                matchingValues := []interface{}{}
-                matchingPaths := []string{}
-                
-                for _, path := range paths {
-                        segments := processor.ConvertPathToSegments(path)
-                        if patternTree.MatchPath(segments) {
-                                matchingPaths = append(matchingPaths, path)
-                                
-                                // Extract the actual value
-                                value, err := processor.ExtractValue(jsonData, path)
-                                if err == nil {
-                                        matchingValues = append(matchingValues, value)
-                                }
-                        }
-                }
-                
-                if outputJSON {
-                        result := map[string]interface{}{
-                                "expression": expression,
-                                "file":       filename,
-                                "matches":    len(matchingValues),
-                                "values":     matchingValues,
-                        }
-                        if verbose {
-                                result["paths"] = matchingPaths
-                        }
-                        
-                        var output []byte
-                        if prettyPrint {
-                                output, _ = json.MarshalIndent(result, "", "  ")
-                        } else {
-                                output, _ = json.Marshal(result)
-                        }
-                        fmt.Println(string(output))
-                } else {
-                        if !quiet && len(matchingValues) > 0 {
-                                fmt.Printf("Found %d matching values:\n", len(matchingValues))
-                                for i, value := range matchingValues {
-                                        fmt.Printf("[%d] %s: %v\n", i+1, matchingPaths[i], value)
-                                }
-                        } else if !quiet {
-                                fmt.Println("No matching values found")
-                        }
-                }
-                
-                if len(matchingValues) == 0 {
-                        os.Exit(1)
-                }
-        },
+	Use:   "extract [expression] [json_file]",
+	Short: "Extract values from JSON data using schema-path expression",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		expression := args[0]
+		filename := args[1]
+
+		// Read JSON file
+		data, err := ioutil.ReadFile(filename)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading file %s: %v\n", filename, err)
+			os.Exit(1)
+		}
+		jsonData := string(data)
+
+		processor := jsonpkg.NewPathExtractor()
+		if err := processor.ValidateJSON(jsonData); err != nil {
+			fmt.Fprintf(os.Stderr, "Invalid JSON in file %s: %v\n", filename, err)
+			os.Exit(1)
+		}
+
+		// Parse the expression
+		expr, err := parser.ParseExpression(expression)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing expression: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Build pattern tree and extract matching paths
+		patternTree := tree.NewPatternTree()
+		if err := patternTree.AddPattern(expr); err != nil {
+			fmt.Fprintf(os.Stderr, "Error building pattern tree: %v\n", err)
+			os.Exit(1)
+		}
+
+		paths, err := processor.ExtractPaths(jsonData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error extracting paths: %v\n", err)
+			os.Exit(1)
+		}
+
+		matchingValues := []interface{}{}
+		matchingPaths := []string{}
+
+		for _, path := range paths {
+			segments := processor.ConvertPathToSegments(path)
+			if patternTree.MatchSegments(segments) {
+				matchingPaths = append(matchingPaths, path)
+
+				// Extract the actual value
+				value, err := processor.ExtractValue(jsonData, path)
+				if err == nil {
+					matchingValues = append(matchingValues, value)
+				}
+			}
+		}
+
+		if outputJSON {
+			result := map[string]interface{}{
+				"expression": expression,
+				"file":       filename,
+				"matches":    len(matchingValues),
+				"values":     matchingValues,
+			}
+			if verbose {
+				result["paths"] = matchingPaths
+			}
+
+			var output []byte
+			if prettyPrint {
+				output, _ = json.MarshalIndent(result, "", "  ")
+			} else {
+				output, _ = json.Marshal(result)
+			}
+			fmt.Println(string(output))
+		} else {
+			if !quiet && len(matchingValues) > 0 {
+				fmt.Printf("Found %d matching values:\n", len(matchingValues))
+				for i, value := range matchingValues {
+					fmt.Printf("[%d] %s: %v\n", i+1, matchingPaths[i], value)
+				}
+			} else if !quiet {
+				fmt.Println("No matching values found")
+			}
+		}
+
+		if len(matchingValues) == 0 {
+			os.Exit(1)
+		}
+	},
 }
 
 func init() {
-        // Add global flags
-        rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
-        rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Enable quiet mode (minimal output)")
-        rootCmd.PersistentFlags().BoolVarP(&outputJSON, "json", "j", false, "Output results in JSON format")
-        rootCmd.PersistentFlags().BoolVarP(&prettyPrint, "pretty", "p", false, "Pretty print JSON output")
-        
-        // Add command-specific flags
-        testCmd.Flags().StringP("file", "f", "", "Read JSON data from file")
-        
-        // Add all commands
-        rootCmd.AddCommand(parseCmd)
-        rootCmd.AddCommand(testCmd)
-        rootCmd.AddCommand(validateCmd)
-        rootCmd.AddCommand(extractCmd)
+	// Add global flags
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Enable quiet mode (minimal output)")
+	rootCmd.PersistentFlags().BoolVarP(&outputJSON, "json", "j", false, "Output results in JSON format")
+	rootCmd.PersistentFlags().BoolVarP(&prettyPrint, "pretty", "p", false, "Pretty print JSON output")
+
+	// Add command-specific flags
+	testCmd.Flags().StringP("file", "f", "", "Read JSON data from file")
+
+	// Add all commands
+	rootCmd.AddCommand(parseCmd)
+	rootCmd.AddCommand(testCmd)
+	rootCmd.AddCommand(validateCmd)
+	rootCmd.AddCommand(extractCmd)
 }
 
 func main() {
-        if err := rootCmd.Execute(); err != nil {
-                fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-                os.Exit(1)
-        }
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/schemapath/main.go
+++ b/cmd/schemapath/main.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -349,6 +351,66 @@ var extractCmd = &cobra.Command{
 	},
 }
 
+var schemaCmd = &cobra.Command{
+	Use:   "schema [schema_file]",
+	Short: "Generate all schema paths from a JSON Schema document",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		filename := args[0]
+
+		data, err := ioutil.ReadFile(filename)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading schema file %s: %v\n", filename, err)
+			os.Exit(1)
+		}
+
+		processor := jsonpkg.NewPathExtractor()
+
+		absPath, err := filepath.Abs(filename)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving schema path %s: %v\n", filename, err)
+			os.Exit(1)
+		}
+
+		schemaPath := filepath.ToSlash(absPath)
+		if !strings.HasPrefix(schemaPath, "/") {
+			schemaPath = "/" + schemaPath
+		}
+
+		schemaURL := url.URL{Scheme: "file", Path: schemaPath}
+
+		paths, err := processor.ExtractSchemaPathsWithURL(string(data), schemaURL.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error generating schema paths: %v\n", err)
+			os.Exit(1)
+		}
+
+		if outputJSON {
+			result := map[string]interface{}{
+				"file":        filename,
+				"total_paths": len(paths),
+				"paths":       paths,
+			}
+
+			var output []byte
+			if prettyPrint {
+				output, _ = json.MarshalIndent(result, "", "  ")
+			} else {
+				output, _ = json.Marshal(result)
+			}
+			fmt.Println(string(output))
+			return
+		}
+
+		if !quiet {
+			fmt.Printf("Found %d schema paths:\n", len(paths))
+		}
+		for _, path := range paths {
+			fmt.Println(path)
+		}
+	},
+}
+
 func init() {
 	// Add global flags
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
@@ -364,6 +426,7 @@ func init() {
 	rootCmd.AddCommand(testCmd)
 	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(extractCmd)
+	rootCmd.AddCommand(schemaCmd)
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/bytedance/sonic v1.14.1
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.10.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/json/processor.go
+++ b/json/processor.go
@@ -1,12 +1,14 @@
 package json
 
 import (
-        "fmt"
-        "strconv"
-        "strings"
+	"fmt"
+	"strconv"
+	"strings"
 
-        "github.com/bytedance/sonic"
-        "github.com/bytedance/sonic/ast"
+	"github.com/bytedance/sonic"
+	"github.com/bytedance/sonic/ast"
+
+	"jsonpath-sdk/spec"
 )
 
 // PathExtractor extracts JSON paths from JSON data using sonic
@@ -14,182 +16,220 @@ type PathExtractor struct{}
 
 // NewPathExtractor creates a new path extractor
 func NewPathExtractor() *PathExtractor {
-        return &PathExtractor{}
+	return &PathExtractor{}
 }
 
 // ExtractPaths extracts all possible JSON paths from the given JSON data using AST
 func (pe *PathExtractor) ExtractPaths(jsonData string) ([]string, error) {
-        root, err := sonic.Get([]byte(jsonData))
-        if err != nil {
-                return nil, fmt.Errorf("failed to parse JSON to AST: %w", err)
-        }
+	root, err := sonic.Get([]byte(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JSON to AST: %w", err)
+	}
 
-        paths := []string{}
-        pe.extractPathsFromAST(&root, "$", &paths)
-        return paths, nil
+	paths := []string{}
+	pe.extractPathsFromAST(&root, "$", &paths)
+	return paths, nil
 }
 
 // ExtractValue extracts a specific value from JSON data at the given path using AST
 func (pe *PathExtractor) ExtractValue(jsonData string, path string) (interface{}, error) {
-        root, err := sonic.Get([]byte(jsonData))
-        if err != nil {
-                return nil, fmt.Errorf("failed to parse JSON to AST: %w", err)
-        }
+	root, err := sonic.Get([]byte(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JSON to AST: %w", err)
+	}
 
-        // Convert path to segments and navigate using AST
-        segments := pe.ConvertPathToSegments(path)
-        current := &root
-        
-        for _, segment := range segments {
-                switch current.Type() {
-                case ast.V_OBJECT:
-                        child := current.Get(segment)
-                        if !child.Exists() {
-                                return nil, fmt.Errorf("property '%s' not found", segment)
-                        }
-                        current = child
-                case ast.V_ARRAY:
-                        // Handle array index
-                        if index, err := strconv.Atoi(segment); err == nil {
-                                child := current.Index(index)
-                                if !child.Exists() {
-                                        return nil, fmt.Errorf("array index %d out of bounds", index)
-                                }
-                                current = child
-                        } else {
-                                return nil, fmt.Errorf("invalid array index '%s'", segment)
-                        }
-                default:
-                        return nil, fmt.Errorf("cannot navigate further: %s is not an object or array", segment)
-                }
-        }
-        
-        // Convert AST node to interface{} for return
-        return pe.astNodeToInterface(current)
+	// Convert path to segments and navigate using AST
+	segments := pe.ConvertPathToSegments(path)
+	current := &root
+
+	for _, segment := range segments {
+		switch current.Type() {
+		case ast.V_OBJECT:
+			child := current.Get(segment.Key)
+			if !child.Exists() {
+				return nil, fmt.Errorf("property '%s' not found", segment.Key)
+			}
+			current = child
+		case ast.V_ARRAY:
+			if segment.Type != spec.SegmentArrayIndex {
+				return nil, fmt.Errorf("expected array index, got property '%s'", segment.Key)
+			}
+			child := current.Index(segment.Index)
+			if !child.Exists() {
+				return nil, fmt.Errorf("array index %d out of bounds", segment.Index)
+			}
+			current = child
+		default:
+			return nil, fmt.Errorf("cannot navigate further: %s is not an object or array", segment.Key)
+		}
+	}
+
+	// Convert AST node to interface{} for return
+	return pe.astNodeToInterface(current)
 }
 
 // ValidateJSON validates if a string is valid JSON using sonic AST
 func (pe *PathExtractor) ValidateJSON(jsonData string) error {
-        _, err := sonic.Get([]byte(jsonData))
-        return err
+	_, err := sonic.Get([]byte(jsonData))
+	return err
 }
 
 // extractPathsFromAST recursively extracts paths from AST nodes
 func (pe *PathExtractor) extractPathsFromAST(node *ast.Node, currentPath string, paths *[]string) {
-        *paths = append(*paths, currentPath)
+	*paths = append(*paths, currentPath)
 
-        switch node.Type() {
-        case ast.V_OBJECT:
-                // Use the Map() method for simpler object traversal
-                if objMap, err := node.Map(); err == nil {
-                        for key := range objMap {
-                                child := node.Get(key)
-                                newPath := currentPath + "." + key
-                                pe.extractPathsFromAST(child, newPath, paths)
-                        }
-                }
-        case ast.V_ARRAY:
-                // Use direct index access for array traversal
-                if arraySlice, err := node.Array(); err == nil {
-                        for i := range arraySlice {
-                                child := node.Index(i)
-                                newPath := currentPath + "[" + strconv.Itoa(i) + "]"
-                                pe.extractPathsFromAST(child, newPath, paths)
-                        }
-                }
-        }
+	switch node.Type() {
+	case ast.V_OBJECT:
+		// Use the Map() method for simpler object traversal
+		if objMap, err := node.Map(); err == nil {
+			for key := range objMap {
+				child := node.Get(key)
+				newPath := currentPath + "." + key
+				pe.extractPathsFromAST(child, newPath, paths)
+			}
+		}
+	case ast.V_ARRAY:
+		// Use direct index access for array traversal
+		if arraySlice, err := node.Array(); err == nil {
+			for i := range arraySlice {
+				child := node.Index(i)
+				newPath := currentPath + "[" + strconv.Itoa(i) + "]"
+				pe.extractPathsFromAST(child, newPath, paths)
+			}
+		}
+	}
 }
 
 // FormatJSON formats JSON data using sonic AST for pretty printing
 func (pe *PathExtractor) FormatJSON(jsonData string) (string, error) {
-        root, err := sonic.Get([]byte(jsonData))
-        if err != nil {
-                return "", fmt.Errorf("failed to parse JSON to AST: %w", err)
-        }
+	root, err := sonic.Get([]byte(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse JSON to AST: %w", err)
+	}
 
-        // Convert AST back to formatted JSON
-        formatted, err := root.MarshalJSON()
-        if err != nil {
-                return "", fmt.Errorf("failed to marshal AST to JSON: %w", err)
-        }
+	// Convert AST back to formatted JSON
+	formatted, err := root.MarshalJSON()
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal AST to JSON: %w", err)
+	}
 
-        // Use sonic to format with indentation
-        var data interface{}
-        if err := sonic.UnmarshalString(string(formatted), &data); err != nil {
-                return "", fmt.Errorf("failed to parse formatted JSON: %w", err)
-        }
+	// Use sonic to format with indentation
+	var data interface{}
+	if err := sonic.UnmarshalString(string(formatted), &data); err != nil {
+		return "", fmt.Errorf("failed to parse formatted JSON: %w", err)
+	}
 
-        indented, err := sonic.MarshalIndent(data, "", "  ")
-        if err != nil {
-                return "", fmt.Errorf("failed to indent JSON: %w", err)
-        }
+	indented, err := sonic.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to indent JSON: %w", err)
+	}
 
-        return string(indented), nil
+	return string(indented), nil
 }
 
 // ConvertPathToSegments converts a JSON path string to segments for tree matching
 // Properly handles bracket notation, array indices, and dot notation
-func (pe *PathExtractor) ConvertPathToSegments(path string) []string {
-        // Remove leading $ 
-        if strings.HasPrefix(path, "$") {
-                path = path[1:]
-        }
-        
-        if path == "" {
-                return []string{}
-        }
-        
-        // Handle leading dot
-        if strings.HasPrefix(path, ".") {
-                path = path[1:]
-        }
-        
-        if path == "" {
-                return []string{}
-        }
-        
-        result := []string{}
-        i := 0
-        
-        for i < len(path) {
-                if path[i] == '[' {
-                        // Find closing bracket
-                        end := strings.Index(path[i:], "]")
-                        if end == -1 {
-                                // Malformed path, treat as regular character
-                                result = append(result, string(path[i]))
-                                i++
-                                continue
-                        }
-                        
-                        // Extract bracket content
-                        bracketContent := path[i+1 : i+end]
-                        
-                        // For array indices, convert to property-like segment
-                        // This aligns with how the parser handles bracket notation
-                        if bracketContent != "" {
-                                // Remove quotes if present and treat as property name
-                                if strings.HasPrefix(bracketContent, `"`) && strings.HasSuffix(bracketContent, `"`) {
-                                        bracketContent = bracketContent[1 : len(bracketContent)-1]
-                                }
-                                result = append(result, bracketContent)
-                        }
-                        
-                        i += end + 1
-                } else if path[i] == '.' {
-                        // Skip dots between segments
-                        i++
-                } else {
-                        // Regular property name
-                        start := i
-                        for i < len(path) && path[i] != '.' && path[i] != '[' {
-                                i++
-                        }
-                        if start < i {
-                                result = append(result, path[start:i])
-                        }
-                }
-        }
-        
-        return result
+func (pe *PathExtractor) ConvertPathToSegments(path string) []spec.PathSegment {
+	// Remove leading $
+	if strings.HasPrefix(path, "$") {
+		path = path[1:]
+	}
+
+	if path == "" {
+		return []spec.PathSegment{}
+	}
+
+	// Handle leading dot
+	if strings.HasPrefix(path, ".") {
+		path = path[1:]
+	}
+
+	if path == "" {
+		return []spec.PathSegment{}
+	}
+
+	result := []spec.PathSegment{}
+	i := 0
+
+	for i < len(path) {
+		if path[i] == '[' {
+			// Find closing bracket
+			end := strings.Index(path[i:], "]")
+			if end == -1 {
+				// Malformed path, treat as regular character
+				result = append(result, spec.NewPropertySegment(string(path[i])))
+				i++
+				continue
+			}
+
+			// Extract bracket content
+			bracketContent := path[i+1 : i+end]
+
+			// For array indices, convert to property-like segment
+			// This aligns with how the parser handles bracket notation
+			if bracketContent != "" {
+				if strings.HasPrefix(bracketContent, `"`) && strings.HasSuffix(bracketContent, `"`) {
+					bracketContent = bracketContent[1 : len(bracketContent)-1]
+					result = append(result, spec.NewPropertySegment(unescapeJSONString(bracketContent)))
+				} else if isDigits(bracketContent) {
+					if index, err := strconv.Atoi(bracketContent); err == nil {
+						result = append(result, spec.NewArrayIndexSegment(index))
+					} else {
+						result = append(result, spec.NewPropertySegment(bracketContent))
+					}
+				} else {
+					result = append(result, spec.NewPropertySegment(unescapeBracketContent(bracketContent)))
+				}
+			}
+
+			i += end + 1
+		} else if path[i] == '.' {
+			// Skip dots between segments
+			i++
+		} else {
+			// Regular property name
+			start := i
+			for i < len(path) && path[i] != '.' && path[i] != '[' {
+				i++
+			}
+			if start < i {
+				result = append(result, spec.NewPropertySegment(path[start:i]))
+			}
+		}
+	}
+
+	return result
+}
+
+func isDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func unescapeBracketContent(value string) string {
+	var builder strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] == '\\' && i+1 < len(value) {
+			i++
+		}
+		builder.WriteByte(value[i])
+	}
+	return builder.String()
+}
+
+func unescapeJSONString(value string) string {
+	// The content is already without surrounding quotes but may contain escapes.
+	// Use strconv.Unquote to decode by adding surrounding quotes back.
+	decoded, err := strconv.Unquote("\"" + value + "\"")
+	if err != nil {
+		return value
+	}
+	return decoded
 }

--- a/json/processor_test.go
+++ b/json/processor_test.go
@@ -176,7 +176,7 @@ func TestExtractValue(t *testing.T) {
 	pe := NewPathExtractor()
 
 	jsonData := `{
-		"user": {
+                "user": {
 			"name": "John",
 			"contacts": [
 				{"type": "email", "value": "john@example.com"}
@@ -233,5 +233,61 @@ func TestExtractValue(t *testing.T) {
 				t.Errorf("ExtractValue(%s) = %v, expected %v", tt.path, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestExtractSchemaPaths(t *testing.T) {
+	pe := NewPathExtractor()
+
+	schema := `{
+                "type": "object",
+                "properties": {
+                        "name": {"type": "string"},
+                        "address": {
+                                "type": "object",
+                                "properties": {
+                                        "street": {"type": "string"},
+                                        "phones": {
+                                                "type": "array",
+                                                "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                                "type": {"type": "string"}
+                                                        }
+                                                }
+                                        }
+                                }
+                        }
+                }
+        }`
+
+	paths, err := pe.ExtractSchemaPaths(schema)
+	if err != nil {
+		t.Fatalf("ExtractSchemaPaths failed: %v", err)
+	}
+
+	expected := []string{
+		"$",
+		"$.address",
+		"$.address.phones",
+		"$.address.phones[*]",
+		"$.address.phones[*].type",
+		"$.address.street",
+		"$.name",
+	}
+
+	if len(paths) != len(expected) {
+		t.Fatalf("expected %d paths, got %d: %v", len(expected), len(paths), paths)
+	}
+
+	pathSet := make(map[string]bool)
+	for _, p := range paths {
+		pathSet[p] = true
+	}
+
+	for _, exp := range expected {
+		if !pathSet[exp] {
+			t.Errorf("expected schema path %s not found", exp)
+		}
 	}
 }

--- a/json/processor_test.go
+++ b/json/processor_test.go
@@ -3,6 +3,8 @@ package json
 import (
 	"reflect"
 	"testing"
+
+	"jsonpath-sdk/spec"
 )
 
 func TestConvertPathToSegments(t *testing.T) {
@@ -11,42 +13,57 @@ func TestConvertPathToSegments(t *testing.T) {
 	tests := []struct {
 		name     string
 		path     string
-		expected []string
+		expected []spec.PathSegment
 	}{
 		{
 			name:     "simple property path",
 			path:     "$.user.name",
-			expected: []string{"user", "name"},
+			expected: []spec.PathSegment{spec.NewPropertySegment("user"), spec.NewPropertySegment("name")},
 		},
 		{
 			name:     "array index path",
 			path:     "$.users[0].name",
-			expected: []string{"users", "0", "name"},
+			expected: []spec.PathSegment{spec.NewPropertySegment("users"), spec.NewArrayIndexSegment(0), spec.NewPropertySegment("name")},
 		},
 		{
-			name:     "multiple array indices",
-			path:     "$.data.users[0].contacts[1].email",
-			expected: []string{"data", "users", "0", "contacts", "1", "email"},
+			name: "multiple array indices",
+			path: "$.data.users[0].contacts[1].email",
+			expected: []spec.PathSegment{
+				spec.NewPropertySegment("data"),
+				spec.NewPropertySegment("users"),
+				spec.NewArrayIndexSegment(0),
+				spec.NewPropertySegment("contacts"),
+				spec.NewArrayIndexSegment(1),
+				spec.NewPropertySegment("email"),
+			},
 		},
 		{
 			name:     "quoted bracket property",
 			path:     `$.data["property-name"].value`,
-			expected: []string{"data", "property-name", "value"},
+			expected: []spec.PathSegment{spec.NewPropertySegment("data"), spec.NewPropertySegment("property-name"), spec.NewPropertySegment("value")},
 		},
 		{
 			name:     "root only",
 			path:     "$",
-			expected: []string{},
+			expected: []spec.PathSegment{},
 		},
 		{
 			name:     "single property",
 			path:     "$.name",
-			expected: []string{"name"},
+			expected: []spec.PathSegment{spec.NewPropertySegment("name")},
 		},
 		{
-			name:     "complex nested",
-			path:     "$.api.responses[0].data.users[2].profile",
-			expected: []string{"api", "responses", "0", "data", "users", "2", "profile"},
+			name: "complex nested",
+			path: "$.api.responses[0].data.users[2].profile",
+			expected: []spec.PathSegment{
+				spec.NewPropertySegment("api"),
+				spec.NewPropertySegment("responses"),
+				spec.NewArrayIndexSegment(0),
+				spec.NewPropertySegment("data"),
+				spec.NewPropertySegment("users"),
+				spec.NewArrayIndexSegment(2),
+				spec.NewPropertySegment("profile"),
+			},
 		},
 	}
 
@@ -62,7 +79,7 @@ func TestConvertPathToSegments(t *testing.T) {
 
 func TestExtractPaths(t *testing.T) {
 	pe := NewPathExtractor()
-	
+
 	jsonData := `{
 		"user": {
 			"name": "John",
@@ -83,7 +100,7 @@ func TestExtractPaths(t *testing.T) {
 		"$",
 		"$.user",
 		"$.user.name",
-		"$.user.age", 
+		"$.user.age",
 		"$.user.contacts",
 		"$.user.contacts[0]",
 		"$.user.contacts[0].type",
@@ -157,7 +174,7 @@ func TestValidateJSON(t *testing.T) {
 
 func TestExtractValue(t *testing.T) {
 	pe := NewPathExtractor()
-	
+
 	jsonData := `{
 		"user": {
 			"name": "John",

--- a/json/schema_paths.go
+++ b/json/schema_paths.go
@@ -1,0 +1,241 @@
+package json
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+type schemaVisitKey struct {
+	schema *jsonschema.Schema
+	path   string
+}
+
+const defaultSchemaURL = "inline.json"
+
+// ExtractSchemaPaths generates all possible schema paths from a JSON Schema document.
+// The returned paths are JSONPath-like expressions rooted at $. Object properties use
+// dot notation when possible and fall back to bracket notation with proper escaping.
+// Array items are represented using either concrete indices (for tuple validation)
+// or the wildcard form "[*]" when the schema applies to any position.
+func (pe *PathExtractor) ExtractSchemaPaths(schemaData string) ([]string, error) {
+	return pe.ExtractSchemaPathsWithURL(schemaData, defaultSchemaURL)
+}
+
+// ExtractSchemaPathsWithURL behaves like ExtractSchemaPaths but allows specifying a base URL
+// that is used when compiling the schema. This is useful when the schema contains relative $ref
+// references that should be resolved from a known location.
+func (pe *PathExtractor) ExtractSchemaPathsWithURL(schemaData, resourceURL string) ([]string, error) {
+	if resourceURL == "" {
+		resourceURL = defaultSchemaURL
+	}
+
+	compiled, err := jsonschema.CompileString(resourceURL, schemaData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile JSON schema: %w", err)
+	}
+
+	paths := make(map[string]struct{})
+	visited := make(map[schemaVisitKey]struct{})
+	stack := make(map[*jsonschema.Schema]bool)
+
+	pe.collectSchemaPaths(compiled, "$", paths, visited, stack)
+
+	result := make([]string, 0, len(paths))
+	for path := range paths {
+		result = append(result, path)
+	}
+
+	sort.Strings(result)
+	return result, nil
+}
+
+func (pe *PathExtractor) collectSchemaPaths(schema *jsonschema.Schema, currentPath string, paths map[string]struct{}, visited map[schemaVisitKey]struct{}, stack map[*jsonschema.Schema]bool) {
+	if schema == nil {
+		return
+	}
+
+	if currentPath == "" {
+		currentPath = "$"
+	}
+
+	addPath(paths, currentPath)
+
+	key := schemaVisitKey{schema: schema, path: currentPath}
+	if _, seen := visited[key]; seen {
+		return
+	}
+	visited[key] = struct{}{}
+
+	if stack[schema] {
+		return
+	}
+
+	stack[schema] = true
+	defer delete(stack, schema)
+
+	pe.collectSchemaPaths(schema.Ref, currentPath, paths, visited, stack)
+	pe.collectSchemaPaths(schema.RecursiveRef, currentPath, paths, visited, stack)
+	pe.collectSchemaPaths(schema.DynamicRef, currentPath, paths, visited, stack)
+
+	if schema.Not != nil {
+		pe.collectSchemaPaths(schema.Not, currentPath, paths, visited, stack)
+	}
+
+	for _, sub := range schema.AllOf {
+		pe.collectSchemaPaths(sub, currentPath, paths, visited, stack)
+	}
+	for _, sub := range schema.AnyOf {
+		pe.collectSchemaPaths(sub, currentPath, paths, visited, stack)
+	}
+	for _, sub := range schema.OneOf {
+		pe.collectSchemaPaths(sub, currentPath, paths, visited, stack)
+	}
+
+	if schema.If != nil {
+		pe.collectSchemaPaths(schema.If, currentPath, paths, visited, stack)
+	}
+	if schema.Then != nil {
+		pe.collectSchemaPaths(schema.Then, currentPath, paths, visited, stack)
+	}
+	if schema.Else != nil {
+		pe.collectSchemaPaths(schema.Else, currentPath, paths, visited, stack)
+	}
+
+	for name, sub := range schema.Properties {
+		childPath := currentPath + formatPropertySegment(name)
+		pe.collectSchemaPaths(sub, childPath, paths, visited, stack)
+	}
+
+	for pattern, sub := range schema.PatternProperties {
+		childPath := currentPath + "[~" + pattern.String() + "]"
+		pe.collectSchemaPaths(sub, childPath, paths, visited, stack)
+	}
+
+	switch addProps := schema.AdditionalProperties.(type) {
+	case bool:
+		if addProps {
+			addPath(paths, currentPath+"[#*]")
+		}
+	case *jsonschema.Schema:
+		pe.collectSchemaPaths(addProps, currentPath+"[#*]", paths, visited, stack)
+	}
+
+	if schema.UnevaluatedProperties != nil {
+		pe.collectSchemaPaths(schema.UnevaluatedProperties, currentPath+"[#*]", paths, visited, stack)
+	}
+
+	for _, sub := range schema.DependentSchemas {
+		pe.collectSchemaPaths(sub, currentPath, paths, visited, stack)
+	}
+
+	for _, dep := range schema.Dependencies {
+		if sub, ok := dep.(*jsonschema.Schema); ok {
+			pe.collectSchemaPaths(sub, currentPath, paths, visited, stack)
+		}
+	}
+
+	pe.expandArraySchemas(schema, currentPath, paths, visited, stack)
+}
+
+func (pe *PathExtractor) expandArraySchemas(schema *jsonschema.Schema, currentPath string, paths map[string]struct{}, visited map[schemaVisitKey]struct{}, stack map[*jsonschema.Schema]bool) {
+	for idx, sub := range schema.PrefixItems {
+		childPath := fmt.Sprintf("%s[%d]", currentPath, idx)
+		pe.collectSchemaPaths(sub, childPath, paths, visited, stack)
+	}
+
+	switch items := schema.Items.(type) {
+	case *jsonschema.Schema:
+		pe.collectSchemaPaths(items, currentPath+"[*]", paths, visited, stack)
+	case []*jsonschema.Schema:
+		for idx, sub := range items {
+			childPath := fmt.Sprintf("%s[%d]", currentPath, idx)
+			pe.collectSchemaPaths(sub, childPath, paths, visited, stack)
+		}
+	}
+
+	switch addItems := schema.AdditionalItems.(type) {
+	case bool:
+		if addItems {
+			addPath(paths, currentPath+"[*]")
+		}
+	case *jsonschema.Schema:
+		pe.collectSchemaPaths(addItems, currentPath+"[*]", paths, visited, stack)
+	}
+
+	if schema.Items2020 != nil {
+		pe.collectSchemaPaths(schema.Items2020, currentPath+"[*]", paths, visited, stack)
+	}
+
+	if schema.Contains != nil {
+		pe.collectSchemaPaths(schema.Contains, currentPath+"[*]", paths, visited, stack)
+	}
+
+	if schema.UnevaluatedItems != nil {
+		pe.collectSchemaPaths(schema.UnevaluatedItems, currentPath+"[*]", paths, visited, stack)
+	}
+
+	if hasSchemaType(schema, "array") && len(schema.PrefixItems) == 0 && schema.Items == nil && schema.Items2020 == nil && schema.Contains == nil {
+		addPath(paths, currentPath+"[*]")
+	}
+}
+
+func addPath(paths map[string]struct{}, path string) {
+	if _, exists := paths[path]; !exists {
+		paths[path] = struct{}{}
+	}
+}
+
+func hasSchemaType(schema *jsonschema.Schema, target string) bool {
+	if schema == nil {
+		return false
+	}
+	for _, t := range schema.Types {
+		if t == target {
+			return true
+		}
+	}
+	return false
+}
+
+func formatPropertySegment(name string) string {
+	if isIdentifier(name) {
+		return "." + name
+	}
+	return "[\"" + escapePropertyName(name) + "\"]"
+}
+
+func isIdentifier(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i, r := range value {
+		if i == 0 {
+			if !(r == '_' || unicode.IsLetter(r)) {
+				return false
+			}
+		} else {
+			if !(r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func escapePropertyName(value string) string {
+	if !strings.ContainsAny(value, "\\\"") {
+		return value
+	}
+	var builder strings.Builder
+	for _, r := range value {
+		if r == '\\' || r == '"' {
+			builder.WriteByte('\\')
+		}
+		builder.WriteRune(r)
+	}
+	return builder.String()
+}

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -1,217 +1,170 @@
 package parser
 
 import (
-        "fmt"
-        "unicode"
+	"fmt"
+	"unicode"
 
-        "jsonpath-sdk/spec"
+	"jsonpath-sdk/spec"
 )
 
-// Lexer tokenizes JSON path expressions
+// Lexer tokenizes schema-path expressions.
 type Lexer struct {
-        input    string
-        position int
-        current  byte
-        tokens   []spec.Token
+	input    string
+	position int
+	current  byte
+	tokens   []spec.Token
 }
 
-// NewLexer creates a new lexer for the given input
+// NewLexer creates a new lexer for the given input.
 func NewLexer(input string) *Lexer {
-        l := &Lexer{
-                input:   input,
-                tokens:  make([]spec.Token, 0),
-        }
-        if len(input) > 0 {
-                l.current = input[0]
-        }
-        return l
+	l := &Lexer{
+		input:  input,
+		tokens: make([]spec.Token, 0),
+	}
+	if len(input) > 0 {
+		l.current = input[0]
+	}
+	return l
 }
 
-// advance moves to the next character
 func (l *Lexer) advance() {
-        l.position++
-        if l.position >= len(l.input) {
-                l.current = 0 // EOF
-        } else {
-                l.current = l.input[l.position]
-        }
+	l.position++
+	if l.position >= len(l.input) {
+		l.current = 0
+		return
+	}
+	l.current = l.input[l.position]
 }
 
-// peek returns the next character without advancing
-func (l *Lexer) peek() byte {
-        nextPos := l.position + 1
-        if nextPos >= len(l.input) {
-                return 0
-        }
-        return l.input[nextPos]
-}
-
-// skipWhitespace skips whitespace characters
 func (l *Lexer) skipWhitespace() {
-        for l.current != 0 && unicode.IsSpace(rune(l.current)) {
-                l.advance()
-        }
+	for l.current != 0 && unicode.IsSpace(rune(l.current)) {
+		l.advance()
+	}
 }
 
-// readIdentifier reads an identifier following [a-zA-Z_][a-zA-Z0-9_]*
+func (l *Lexer) addToken(tokenType spec.TokenType, value string, quoted bool) {
+	l.tokens = append(l.tokens, spec.Token{
+		Type:     tokenType,
+		Value:    value,
+		Position: l.position,
+		Quoted:   quoted,
+	})
+}
+
 func (l *Lexer) readIdentifier() string {
-        start := l.position
-        
-        // First character must be letter or underscore
-        if !isLetter(l.current) && l.current != '_' {
-                return ""
-        }
-        
-        l.advance()
-        
-        // Subsequent characters can be letters, digits, or underscore
-        for l.current != 0 && (isLetterOrDigit(l.current) || l.current == '_') {
-                l.advance()
-        }
-        
-        return l.input[start:l.position]
+	start := l.position
+	if !(isLetter(l.current) || l.current == '_') {
+		return ""
+	}
+	l.advance()
+	for l.current != 0 && (isLetter(l.current) || isDigit(l.current) || l.current == '_') {
+		l.advance()
+	}
+	return l.input[start:l.position]
 }
 
-// readBracketContent reads content inside brackets until closing ]
 func (l *Lexer) readBracketContent() (string, bool, error) {
-        start := l.position
-        quoted := false
-        
-        // Check if content starts with quote
-        if l.current == '"' {
-                quoted = true
-                l.advance() // skip opening quote
-                start = l.position // start after the quote
-                
-                // Read until closing quote
-                for l.current != 0 && l.current != '"' {
-                        if l.current == '\\' {
-                                l.advance() // skip escape char
-                                if l.current != 0 {
-                                        l.advance() // skip escaped char
-                                }
-                        } else {
-                                l.advance()
-                        }
-                }
-                
-                if l.current != '"' {
-                        return "", false, fmt.Errorf("unterminated quoted string in bracket notation")
-                }
-                
-                content := l.input[start:l.position]
-                l.advance() // skip closing quote
-                return content, quoted, nil
-        }
-        
-        // Read unquoted content until ]
-        for l.current != 0 && l.current != ']' {
-                if l.current == '\\' {
-                        l.advance() // skip escape char
-                        if l.current != 0 {
-                                l.advance() // skip escaped char
-                        }
-                } else {
-                        l.advance()
-                }
-        }
-        
-        content := l.input[start:l.position]
-        return content, quoted, nil
+	if l.current == '"' {
+		l.advance()
+		buf := make([]byte, 0)
+		for {
+			if l.current == 0 {
+				return "", false, fmt.Errorf("unterminated quoted string in bracket notation")
+			}
+			if l.current == '"' {
+				l.advance()
+				break
+			}
+			if l.current == '\\' {
+				l.advance()
+				if l.current == 0 {
+					return "", false, fmt.Errorf("unterminated escape sequence in bracket notation")
+				}
+			}
+			buf = append(buf, l.current)
+			l.advance()
+		}
+		return string(buf), true, nil
+	}
+
+	buf := make([]byte, 0)
+	for l.current != 0 && l.current != ']' {
+		if l.current == '\\' {
+			l.advance()
+			if l.current == 0 {
+				return "", false, fmt.Errorf("unterminated escape sequence in bracket notation")
+			}
+		}
+		buf = append(buf, l.current)
+		l.advance()
+	}
+	return string(buf), false, nil
 }
 
-// addToken adds a token to the tokens slice
-func (l *Lexer) addToken(tokenType spec.TokenType, value string) {
-        l.tokens = append(l.tokens, spec.Token{
-                Type:     tokenType,
-                Value:    value,
-                Position: l.position,
-        })
-}
-
-// Tokenize converts the input string into tokens
+// Tokenize converts the input string into tokens understood by the parser.
 func (l *Lexer) Tokenize() ([]spec.Token, error) {
-        for l.current != 0 {
-                l.skipWhitespace()
-                
-                if l.current == 0 {
-                        break
-                }
-                
-                switch l.current {
-                case '$':
-                        l.addToken(spec.TokenRoot, "$")
-                        l.advance()
-                case '.':
-                        l.addToken(spec.TokenDot, ".")
-                        l.advance()
-                case '[':
-                        l.advance() // skip opening bracket
-                        content, quoted, err := l.readBracketContent()
-                        if err != nil {
-                                return nil, err
-                        }
-                        if l.current != ']' {
-                                return nil, fmt.Errorf("expected closing bracket ']' at position %d", l.position)
-                        }
-                        
-                        // Store the content with metadata about quoting
-                        if quoted {
-                                l.addToken(spec.TokenString, `"`+content+`"`)
-                        } else {
-                                l.addToken(spec.TokenString, content)
-                        }
-                        l.advance() // skip closing bracket
-                case ']':
-                        l.addToken(spec.TokenRBracket, "]")
-                        l.advance()
-                case '(':
-                        l.addToken(spec.TokenLParen, "(")
-                        l.advance()
-                case ')':
-                        l.addToken(spec.TokenRParen, ")")
-                        l.advance()
-                case '|':
-                        l.addToken(spec.TokenPipe, "|")
-                        l.advance()
-                case '{':
-                        l.advance()
-                        if l.current == '*' {
-                                l.advance()
-                                if l.current == '}' {
-                                        l.addToken(spec.TokenStar, "{*}")
-                                        l.advance()
-                                } else {
-                                        return nil, fmt.Errorf("expected '}' after '{*' at position %d", l.position)
-                                }
-                        } else {
-                                l.addToken(spec.TokenLBrace, "{")
-                        }
-                case '}':
-                        l.addToken(spec.TokenRBrace, "}")
-                        l.advance()
-                default:
-                        if isLetter(l.current) || l.current == '_' {
-                                identifier := l.readIdentifier()
-                                if identifier == "" {
-                                        return nil, fmt.Errorf("invalid identifier at position %d", l.position)
-                                }
-                                l.addToken(spec.TokenIdentifier, identifier)
-                        } else {
-                                return nil, fmt.Errorf("unexpected character '%c' at position %d", l.current, l.position)
-                        }
-                }
-        }
-        
-        l.addToken(spec.TokenEOF, "")
-        return l.tokens, nil
+	for l.current != 0 {
+		l.skipWhitespace()
+		if l.current == 0 {
+			break
+		}
+
+		switch l.current {
+		case '$':
+			l.addToken(spec.TokenRoot, "$", false)
+			l.advance()
+		case '.':
+			l.addToken(spec.TokenDot, ".", false)
+			l.advance()
+		case '(':
+			l.addToken(spec.TokenLParen, "(", false)
+			l.advance()
+		case ')':
+			l.addToken(spec.TokenRParen, ")", false)
+			l.advance()
+		case '|':
+			l.addToken(spec.TokenPipe, "|", false)
+			l.advance()
+		case '[':
+			l.advance()
+			content, quoted, err := l.readBracketContent()
+			if err != nil {
+				return nil, err
+			}
+			if l.current != ']' {
+				return nil, fmt.Errorf("expected closing ']' at position %d", l.position)
+			}
+			l.addToken(spec.TokenBracket, content, quoted)
+			l.advance()
+		case '{':
+			startPos := l.position
+			l.advance()
+			if l.current != '*' {
+				return nil, fmt.Errorf("unexpected character '{' at position %d", startPos)
+			}
+			l.advance()
+			if l.current != '}' {
+				return nil, fmt.Errorf("expected '}' to close repetition at position %d", l.position)
+			}
+			l.advance()
+			l.addToken(spec.TokenStar, "{*}", false)
+		default:
+			if ident := l.readIdentifier(); ident != "" {
+				l.addToken(spec.TokenIdentifier, ident, false)
+			} else {
+				return nil, fmt.Errorf("unexpected character '%c' at position %d", l.current, l.position)
+			}
+		}
+	}
+
+	l.addToken(spec.TokenEOF, "", false)
+	return l.tokens, nil
 }
 
-// Helper functions
 func isLetter(ch byte) bool {
-        return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
 }
 
-func isLetterOrDigit(ch byte) bool {
-        return isLetter(ch) || (ch >= '0' && ch <= '9')
+func isDigit(ch byte) bool {
+	return ch >= '0' && ch <= '9'
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,293 +1,280 @@
 package parser
 
 import (
-        "fmt"
+	"fmt"
+	"regexp"
+	"strconv"
 
-        "jsonpath-sdk/spec"
+	"jsonpath-sdk/spec"
 )
 
-// Parser implements a recursive descent parser for JSON path expressions
+// Parser implements a recursive descent parser for schema-path expressions.
 type Parser struct {
-        tokens   []spec.Token
-        position int
-        current  spec.Token
+	tokens   []spec.Token
+	position int
+	current  spec.Token
 }
 
-// NewParser creates a new parser with the given tokens
+// NewParser creates a new parser with the provided tokens.
 func NewParser(tokens []spec.Token) *Parser {
-        p := &Parser{
-                tokens:   tokens,
-                position: 0,
-        }
-        if len(tokens) > 0 {
-                p.current = tokens[0]
-        }
-        return p
+	p := &Parser{tokens: tokens}
+	if len(tokens) > 0 {
+		p.current = tokens[0]
+	}
+	return p
 }
 
-// advance moves to the next token
 func (p *Parser) advance() {
-        p.position++
-        if p.position >= len(p.tokens) {
-                p.current = spec.Token{Type: spec.TokenEOF}
-        } else {
-                p.current = p.tokens[p.position]
-        }
+	p.position++
+	if p.position >= len(p.tokens) {
+		p.current = spec.Token{Type: spec.TokenEOF}
+		return
+	}
+	p.current = p.tokens[p.position]
 }
 
-// peek returns the next token without advancing
-func (p *Parser) peek() spec.Token {
-        nextPos := p.position + 1
-        if nextPos >= len(p.tokens) {
-                return spec.Token{Type: spec.TokenEOF}
-        }
-        return p.tokens[nextPos]
-}
-
-// expect checks if current token matches expected type and advances
 func (p *Parser) expect(tokenType spec.TokenType) error {
-        if p.current.Type != tokenType {
-                return fmt.Errorf("expected %v, got %v at position %d", tokenType, p.current.Type, p.current.Position)
-        }
-        p.advance()
-        return nil
+	if p.current.Type != tokenType {
+		return fmt.Errorf("expected %v at position %d", tokenType, p.current.Position)
+	}
+	p.advance()
+	return nil
 }
 
-// Parse parses the tokens into an AST
-// Expression ::= Root Path?
+// Parse converts tokens into a PathExpression AST.
 func (p *Parser) Parse() (*spec.PathExpression, error) {
-        expr := &spec.PathExpression{}
-        
-        // Parse root
-        root, err := p.parseRoot()
-        if err != nil {
-                return nil, err
-        }
-        expr.Root = root
-        
-        // Parse optional path
-        if p.current.Type != spec.TokenEOF {
-                segments, err := p.parsePath()
-                if err != nil {
-                        return nil, err
-                }
-                expr.Segments = segments
-        }
-        
-        // Ensure we've consumed all tokens
-        if p.current.Type != spec.TokenEOF {
-                return nil, fmt.Errorf("unexpected token %v at position %d", p.current.Type, p.current.Position)
-        }
-        
-        return expr, nil
+	expr := &spec.PathExpression{}
+
+	if err := p.expect(spec.TokenRoot); err != nil {
+		return nil, fmt.Errorf("expression must start with '$': %w", err)
+	}
+	expr.Root = &spec.RootNode{}
+
+	segments, err := p.parsePath()
+	if err != nil {
+		return nil, err
+	}
+	expr.Segments = segments
+
+	if p.current.Type != spec.TokenEOF {
+		return nil, fmt.Errorf("unexpected token %v at position %d", p.current.Type, p.current.Position)
+	}
+	return expr, nil
 }
 
-// parseRoot parses the root token
-// Root ::= "$"
-func (p *Parser) parseRoot() (*spec.RootNode, error) {
-        if err := p.expect(spec.TokenRoot); err != nil {
-                return nil, err
-        }
-        return &spec.RootNode{}, nil
-}
-
-// parsePath parses a path sequence
-// Path ::= Segment*
 func (p *Parser) parsePath() ([]spec.ASTNode, error) {
-        segments := make([]spec.ASTNode, 0)
-        
-        for p.current.Type != spec.TokenEOF {
-                segment, err := p.parseSegment()
-                if err != nil {
-                        return nil, err
-                }
-                if segment == nil {
-                        break
-                }
-                segments = append(segments, segment)
-        }
-        
-        return segments, nil
+	segments := make([]spec.ASTNode, 0)
+	for {
+		segment, err := p.parseSegment()
+		if err != nil {
+			return nil, err
+		}
+		if segment == nil {
+			break
+		}
+		segments = append(segments, segment)
+	}
+	return segments, nil
 }
 
-// parseSegment parses a single segment
-// Segment ::= "." SegmentItem | BracketNotation
 func (p *Parser) parseSegment() (spec.ASTNode, error) {
-        switch p.current.Type {
-        case spec.TokenDot:
-                p.advance() // consume "."
-                return p.parseSegmentItem()
-                
-        case spec.TokenString:
-                // This represents bracket notation content from lexer
-                content := p.current.Value
-                p.advance()
-                
-                // Check if quoted (starts and ends with quotes)
-                quoted := false
-                if len(content) >= 2 && content[0] == '"' && content[len(content)-1] == '"' {
-                        quoted = true
-                        content = content[1 : len(content)-1] // remove quotes
-                }
-                
-                return &spec.BracketNode{Content: content, Quoted: quoted}, nil
-                
-        default:
-                return nil, nil // no more segments
-        }
+	switch p.current.Type {
+	case spec.TokenDot:
+		p.advance()
+		return p.parseSegmentItem()
+	case spec.TokenBracket:
+		bracket, err := p.consumeBracket()
+		if err != nil {
+			return nil, err
+		}
+		return bracket, nil
+	default:
+		return nil, nil
+	}
 }
 
-// parseSegmentItem parses a segment item
-// SegmentItem ::= Identifier | GroupExpression
 func (p *Parser) parseSegmentItem() (spec.ASTNode, error) {
-        switch p.current.Type {
-        case spec.TokenIdentifier:
-                name := p.current.Value
-                p.advance()
-                return &spec.PropertyNode{Name: name}, nil
-                
-        case spec.TokenLParen:
-                return p.parseGroupExpression()
-                
-        default:
-                return nil, fmt.Errorf("expected identifier or group expression, got %v at position %d", p.current.Type, p.current.Position)
-        }
+	switch p.current.Type {
+	case spec.TokenIdentifier:
+		node := &spec.PropertyNode{Name: p.current.Value}
+		p.advance()
+		if p.current.Type == spec.TokenStar {
+			p.advance()
+			return &spec.RepetitionNode{Sequence: []spec.ASTNode{node}}, nil
+		}
+		return node, nil
+	case spec.TokenLParen:
+		return p.parseGroupExpression()
+	default:
+		return nil, fmt.Errorf("expected property or group at position %d", p.current.Position)
+	}
 }
 
-// parseGroupExpression parses a group expression with optional repetition
-// GroupExpression ::= "(" GroupSeq ("|" GroupSeq)* ")" Repetition?
 func (p *Parser) parseGroupExpression() (*spec.GroupNode, error) {
-        if err := p.expect(spec.TokenLParen); err != nil {
-                return nil, err
-        }
-        
-        group := &spec.GroupNode{
-                Alternatives: make([][]spec.ASTNode, 0),
-        }
-        
-        // Parse first sequence
-        firstSeq, err := p.parseGroupSeq()
-        if err != nil {
-                return nil, err
-        }
-        group.Alternatives = append(group.Alternatives, firstSeq)
-        
-        // Parse additional alternatives
-        for p.current.Type == spec.TokenPipe {
-                p.advance() // consume "|"
-                seq, err := p.parseGroupSeq()
-                if err != nil {
-                        return nil, err
-                }
-                group.Alternatives = append(group.Alternatives, seq)
-        }
-        
-        if err := p.expect(spec.TokenRParen); err != nil {
-                return nil, err
-        }
-        
-        // Check for optional repetition
-        if p.current.Type == spec.TokenStar {
-                group.Repetition = true
-                p.advance()
-        }
-        
-        return group, nil
+	if err := p.expect(spec.TokenLParen); err != nil {
+		return nil, err
+	}
+
+	alternatives := make([][]spec.ASTNode, 0)
+	seq, err := p.parseGroupSeq()
+	if err != nil {
+		return nil, err
+	}
+	if len(seq) == 0 {
+		return nil, fmt.Errorf("group alternative cannot be empty at position %d", p.current.Position)
+	}
+	alternatives = append(alternatives, seq)
+
+	for p.current.Type == spec.TokenPipe {
+		p.advance()
+		nextSeq, err := p.parseGroupSeq()
+		if err != nil {
+			return nil, err
+		}
+		if len(nextSeq) == 0 {
+			return nil, fmt.Errorf("group alternative cannot be empty at position %d", p.current.Position)
+		}
+		alternatives = append(alternatives, nextSeq)
+	}
+
+	if err := p.expect(spec.TokenRParen); err != nil {
+		return nil, err
+	}
+
+	group := &spec.GroupNode{Alternatives: alternatives}
+	if p.current.Type == spec.TokenStar {
+		group.Repetition = true
+		p.advance()
+	}
+	return group, nil
 }
 
-// parseGroupSeq parses a group sequence
-// GroupSeq ::= GroupPrimary ("." GroupPrimary)*
 func (p *Parser) parseGroupSeq() ([]spec.ASTNode, error) {
-        sequence := make([]spec.ASTNode, 0)
-        
-        // Parse first primary
-        primary, err := p.parseGroupPrimary()
-        if err != nil {
-                return nil, err
-        }
-        sequence = append(sequence, primary...)
-        
-        // Parse additional primaries separated by dots
-        for p.current.Type == spec.TokenDot {
-                p.advance() // consume "."
-                primary, err := p.parseGroupPrimary()
-                if err != nil {
-                        return nil, err
-                }
-                sequence = append(sequence, primary...)
-        }
-        
-        return sequence, nil
+	sequence := make([]spec.ASTNode, 0)
+	primary, err := p.parseGroupPrimary()
+	if err != nil {
+		return nil, err
+	}
+	sequence = append(sequence, primary...)
+
+	for p.current.Type == spec.TokenDot {
+		p.advance()
+		next, err := p.parseGroupPrimary()
+		if err != nil {
+			return nil, err
+		}
+		sequence = append(sequence, next...)
+	}
+	return sequence, nil
 }
 
-// parseGroupPrimary parses a group primary
-// GroupPrimary ::= Identifier BracketSuffix? | GroupExpression
 func (p *Parser) parseGroupPrimary() ([]spec.ASTNode, error) {
-        switch p.current.Type {
-        case spec.TokenIdentifier:
-                nodes := make([]spec.ASTNode, 0)
-                
-                // Add identifier
-                name := p.current.Value
-                p.advance()
-                nodes = append(nodes, &spec.PropertyNode{Name: name})
-                
-                // Parse optional bracket suffix
-                brackets, err := p.parseBracketSuffix()
-                if err != nil {
-                        return nil, err
-                }
-                nodes = append(nodes, brackets...)
-                
-                return nodes, nil
-                
-        case spec.TokenLParen:
-                group, err := p.parseGroupExpression()
-                if err != nil {
-                        return nil, err
-                }
-                return []spec.ASTNode{group}, nil
-                
-        default:
-                return nil, fmt.Errorf("expected identifier or group expression, got %v at position %d", p.current.Type, p.current.Position)
-        }
+	switch p.current.Type {
+	case spec.TokenIdentifier:
+		sequence := []spec.ASTNode{&spec.PropertyNode{Name: p.current.Value}}
+		p.advance()
+		suffix, err := p.parseBracketSuffix()
+		if err != nil {
+			return nil, err
+		}
+		sequence = append(sequence, suffix...)
+		if p.current.Type == spec.TokenStar {
+			p.advance()
+			return []spec.ASTNode{&spec.RepetitionNode{Sequence: sequence}}, nil
+		}
+		return sequence, nil
+	case spec.TokenLParen:
+		group, err := p.parseGroupExpression()
+		if err != nil {
+			return nil, err
+		}
+		return []spec.ASTNode{group}, nil
+	default:
+		return nil, fmt.Errorf("expected identifier or group at position %d", p.current.Position)
+	}
 }
 
-// parseBracketSuffix parses optional bracket notation after identifier
-// BracketSuffix ::= (BracketNotation)+
 func (p *Parser) parseBracketSuffix() ([]spec.ASTNode, error) {
-        brackets := make([]spec.ASTNode, 0)
-        
-        for p.current.Type == spec.TokenString {
-                content := p.current.Value
-                p.advance()
-                
-                // Check if quoted
-                quoted := false
-                if len(content) >= 2 && content[0] == '"' && content[len(content)-1] == '"' {
-                        quoted = true
-                        content = content[1 : len(content)-1] // remove quotes
-                }
-                
-                brackets = append(brackets, &spec.BracketNode{Content: content, Quoted: quoted})
-        }
-        
-        return brackets, nil
+	nodes := make([]spec.ASTNode, 0)
+	for p.current.Type == spec.TokenBracket {
+		bracket, err := p.consumeBracket()
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, bracket)
+	}
+	return nodes, nil
 }
 
-// ParseExpression is a convenience function that combines lexing and parsing
+func (p *Parser) consumeBracket() (*spec.BracketNode, error) {
+	token := p.current
+	if token.Type != spec.TokenBracket {
+		return nil, fmt.Errorf("internal parser error: expected bracket token, got %v", token.Type)
+	}
+	p.advance()
+	bracket, err := buildBracketNode(token)
+	if err != nil {
+		return nil, err
+	}
+	return bracket, nil
+}
+
+func buildBracketNode(token spec.Token) (*spec.BracketNode, error) {
+	if token.Quoted {
+		return &spec.BracketNode{Kind: spec.BracketProperty, Value: token.Value, Quoted: true}, nil
+	}
+
+	switch {
+	case token.Value == "*":
+		return &spec.BracketNode{Kind: spec.BracketArrayWildcard}, nil
+	case len(token.Value) > 0 && token.Value[0] == '#':
+		if len(token.Value) == 1 {
+			return nil, fmt.Errorf("wildcard pattern cannot be empty")
+		}
+		return &spec.BracketNode{Kind: spec.BracketPropertyWildcard, Value: token.Value[1:]}, nil
+	case len(token.Value) > 0 && token.Value[0] == '~':
+		if len(token.Value) == 1 {
+			return nil, fmt.Errorf("regex pattern cannot be empty")
+		}
+		pattern := token.Value[1:]
+		if _, err := regexp.Compile(pattern); err != nil {
+			return nil, fmt.Errorf("invalid regex pattern %q: %w", pattern, err)
+		}
+		return &spec.BracketNode{Kind: spec.BracketRegex, Value: pattern}, nil
+	case isDigits(token.Value):
+		idx, err := strconv.Atoi(token.Value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid array index %q: %w", token.Value, err)
+		}
+		return &spec.BracketNode{Kind: spec.BracketArrayIndex, Index: idx}, nil
+	default:
+		return &spec.BracketNode{Kind: spec.BracketProperty, Value: token.Value}, nil
+	}
+}
+
+func isDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// ParseExpression tokenizes and parses an input string.
 func ParseExpression(input string) (*spec.PathExpression, error) {
-        lexer := NewLexer(input)
-        tokens, err := lexer.Tokenize()
-        if err != nil {
-                return nil, fmt.Errorf("lexer error: %w", err)
-        }
-        
-        parser := NewParser(tokens)
-        expr, err := parser.Parse()
-        if err != nil {
-                return nil, fmt.Errorf("parser error: %w", err)
-        }
-        
-        return expr, nil
+	lexer := NewLexer(input)
+	tokens, err := lexer.Tokenize()
+	if err != nil {
+		return nil, fmt.Errorf("lexer error: %w", err)
+	}
+	parser := NewParser(tokens)
+	expr, err := parser.Parse()
+	if err != nil {
+		return nil, fmt.Errorf("parser error: %w", err)
+	}
+	return expr, nil
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,193 +1,186 @@
 package parser
 
 import (
-        "testing"
-        "jsonpath-sdk/spec"
+	"testing"
+
+	"jsonpath-sdk/spec"
 )
 
-func TestParseBasicExpressions(t *testing.T) {
-        tests := []struct {
-                name  string
-                input string
-                want  string
-        }{
-                {
-                        name:  "root only",
-                        input: "$",
-                        want:  "$",
-                },
-                {
-                        name:  "simple property",
-                        input: "$.node",
-                        want:  "$.node",
-                },
-                {
-                        name:  "nested property",
-                        input: "$.node.value",
-                        want:  "$.node.value",
-                },
-                {
-                        name:  "bracket notation unquoted",
-                        input: `$[property]`,
-                        want:  "$[property]",
-                },
-                {
-                        name:  "bracket notation quoted",
-                        input: `$["quoted-name"]`,
-                        want:  `$["quoted-name"]`,
-                },
-        }
-
-        for _, tt := range tests {
-                t.Run(tt.name, func(t *testing.T) {
-                        expr, err := ParseExpression(tt.input)
-                        if err != nil {
-                                t.Fatalf("ParseExpression() error = %v", err)
-                        }
-                        
-                        got := expr.String()
-                        if got != tt.want {
-                                t.Errorf("ParseExpression() = %v, want %v", got, tt.want)
-                        }
-                })
-        }
+func TestParseExpressionBasic(t *testing.T) {
+	expr, err := ParseExpression("$.user.name")
+	if err != nil {
+		t.Fatalf("ParseExpression error: %v", err)
+	}
+	if len(expr.Segments) != 2 {
+		t.Fatalf("expected 2 segments, got %d", len(expr.Segments))
+	}
+	first, ok := expr.Segments[0].(*spec.PropertyNode)
+	if !ok || first.Name != "user" {
+		t.Fatalf("expected first segment to be property 'user', got %#v", expr.Segments[0])
+	}
+	second, ok := expr.Segments[1].(*spec.PropertyNode)
+	if !ok || second.Name != "name" {
+		t.Fatalf("expected second segment to be property 'name', got %#v", expr.Segments[1])
+	}
+	if got := expr.String(); got != "$.user.name" {
+		t.Fatalf("unexpected string form: %s", got)
+	}
 }
 
-func TestParseGroupExpressions(t *testing.T) {
-        tests := []struct {
-                name  string
-                input string
-        }{
-                {
-                        name:  "simple group",
-                        input: "$.node.(child|value)",
-                },
-                {
-                        name:  "group with repetition",
-                        input: "$.node.(child|meta.child){*}",
-                },
-                {
-                        name:  "complex recursive structure", 
-                        input: "$.node.(child|meta.child){*}.value",
-                },
-                {
-                        name:  "bracket in group",
-                        input: `$.node.(child|meta["child"]){*}.value`,
-                },
-                {
-                        name:  "multiple brackets in group",
-                        input: `$.data.(items["key"]["subkey"]|nested.values){*}`,
-                },
-        }
+func TestParseExpressionBracketSelectors(t *testing.T) {
+	expr, err := ParseExpression(`$.data["prop"][#user*][~^id\\d+$][0][*]`)
+	if err != nil {
+		t.Fatalf("ParseExpression error: %v", err)
+	}
+	if len(expr.Segments) != 6 {
+		t.Fatalf("expected 6 segments, got %d", len(expr.Segments))
+	}
+	expectKinds := []spec.BracketKind{
+		spec.BracketProperty,
+		spec.BracketPropertyWildcard,
+		spec.BracketRegex,
+		spec.BracketArrayIndex,
+		spec.BracketArrayWildcard,
+	}
+	for i, kind := range expectKinds {
+		bracket, ok := expr.Segments[i+1].(*spec.BracketNode)
+		if !ok {
+			t.Fatalf("segment %d expected bracket node, got %#v", i+1, expr.Segments[i+1])
+		}
+		if bracket.Kind != kind {
+			t.Fatalf("segment %d expected kind %v, got %v", i+1, kind, bracket.Kind)
+		}
+	}
+	if value := expr.Segments[2].(*spec.BracketNode).Value; value != "user*" {
+		t.Fatalf("unexpected wildcard value: %s", value)
+	}
+	if value := expr.Segments[3].(*spec.BracketNode).Value; value != "^id\\d+$" {
+		t.Fatalf("unexpected regex value: %s", value)
+	}
+	if idx := expr.Segments[4].(*spec.BracketNode).Index; idx != 0 {
+		t.Fatalf("expected array index 0, got %d", idx)
+	}
+}
 
-        for _, tt := range tests {
-                t.Run(tt.name, func(t *testing.T) {
-                        expr, err := ParseExpression(tt.input)
-                        if err != nil {
-                                t.Fatalf("ParseExpression() error = %v for input: %s", err, tt.input)
-                        }
-                        
-                        // Basic validation - ensure we got a valid expression
-                        if expr.Root == nil {
-                                t.Error("Expected root node, got nil")
-                        }
-                        
-                        // Check that we can stringify (basic formatting test)
-                        result := expr.String()
-                        if result == "" {
-                                t.Error("String() returned empty result")
-                        }
-                        
-                        t.Logf("Input: %s -> Output: %s", tt.input, result)
-                })
-        }
+func TestParseExpressionGroupAndRepetition(t *testing.T) {
+	expr, err := ParseExpression("$.node.(child|meta.child){*}.value")
+	if err != nil {
+		t.Fatalf("ParseExpression error: %v", err)
+	}
+	if len(expr.Segments) != 3 {
+		t.Fatalf("expected 3 segments, got %d", len(expr.Segments))
+	}
+	group, ok := expr.Segments[1].(*spec.GroupNode)
+	if !ok {
+		t.Fatalf("expected second segment to be group, got %#v", expr.Segments[1])
+	}
+	if !group.Repetition {
+		t.Fatalf("expected group to have repetition")
+	}
+	if len(group.Alternatives) != 2 {
+		t.Fatalf("expected 2 alternatives, got %d", len(group.Alternatives))
+	}
+	if len(group.Alternatives[0]) != 1 {
+		t.Fatalf("expected first alternative length 1, got %d", len(group.Alternatives[0]))
+	}
+	if prop, ok := group.Alternatives[0][0].(*spec.PropertyNode); !ok || prop.Name != "child" {
+		t.Fatalf("unexpected first alternative: %#v", group.Alternatives[0][0])
+	}
+	if len(group.Alternatives[1]) != 2 {
+		t.Fatalf("expected second alternative length 2, got %d", len(group.Alternatives[1]))
+	}
+	if got := expr.String(); got != "$.node.(child|meta.child){*}.value" {
+		t.Fatalf("unexpected string form: %s", got)
+	}
+}
+
+func TestParseExpressionPropertyRepetition(t *testing.T) {
+	expr, err := ParseExpression("$.meta{*}.child")
+	if err != nil {
+		t.Fatalf("ParseExpression error: %v", err)
+	}
+	if len(expr.Segments) != 2 {
+		t.Fatalf("expected 2 segments, got %d", len(expr.Segments))
+	}
+	repeat, ok := expr.Segments[0].(*spec.RepetitionNode)
+	if !ok {
+		t.Fatalf("expected first segment to be repetition node, got %#v", expr.Segments[0])
+	}
+	if len(repeat.Sequence) != 1 {
+		t.Fatalf("expected repetition sequence length 1, got %d", len(repeat.Sequence))
+	}
+	if prop, ok := repeat.Sequence[0].(*spec.PropertyNode); !ok || prop.Name != "meta" {
+		t.Fatalf("unexpected repetition inner node: %#v", repeat.Sequence[0])
+	}
+	if got := expr.String(); got != "$.meta{*}.child" {
+		t.Fatalf("unexpected string form: %s", got)
+	}
 }
 
 func TestLexerTokenization(t *testing.T) {
-        tests := []struct {
-                name     string
-                input    string
-                expected []spec.TokenType
-        }{
-                {
-                        name:  "root only",
-                        input: "$",
-                        expected: []spec.TokenType{spec.TokenRoot, spec.TokenEOF},
-                },
-                {
-                        name:  "simple property",
-                        input: "$.node",
-                        expected: []spec.TokenType{spec.TokenRoot, spec.TokenDot, spec.TokenIdentifier, spec.TokenEOF},
-                },
-                {
-                        name:  "group expression",
-                        input: "$.(child|value)",
-                        expected: []spec.TokenType{spec.TokenRoot, spec.TokenDot, spec.TokenLParen, spec.TokenIdentifier, 
-                                spec.TokenPipe, spec.TokenIdentifier, spec.TokenRParen, spec.TokenEOF},
-                },
-                {
-                        name:  "repetition",
-                        input: "$.(child){*}",
-                        expected: []spec.TokenType{spec.TokenRoot, spec.TokenDot, spec.TokenLParen, spec.TokenIdentifier,
-                                spec.TokenRParen, spec.TokenStar, spec.TokenEOF},
-                },
-        }
+	tests := []struct {
+		name     string
+		input    string
+		expected []spec.TokenType
+	}{
+		{
+			name:     "root only",
+			input:    "$",
+			expected: []spec.TokenType{spec.TokenRoot, spec.TokenEOF},
+		},
+		{
+			name:     "bracket",
+			input:    "$[value]",
+			expected: []spec.TokenType{spec.TokenRoot, spec.TokenBracket, spec.TokenEOF},
+		},
+		{
+			name:  "group",
+			input: "$.node.(child|value)",
+			expected: []spec.TokenType{
+				spec.TokenRoot, spec.TokenDot, spec.TokenIdentifier, spec.TokenDot,
+				spec.TokenLParen, spec.TokenIdentifier, spec.TokenPipe, spec.TokenIdentifier,
+				spec.TokenRParen, spec.TokenEOF,
+			},
+		},
+		{
+			name:  "repetition",
+			input: "$.(child){*}",
+			expected: []spec.TokenType{
+				spec.TokenRoot, spec.TokenDot, spec.TokenLParen, spec.TokenIdentifier,
+				spec.TokenRParen, spec.TokenStar, spec.TokenEOF,
+			},
+		},
+	}
 
-        for _, tt := range tests {
-                t.Run(tt.name, func(t *testing.T) {
-                        lexer := NewLexer(tt.input)
-                        tokens, err := lexer.Tokenize()
-                        if err != nil {
-                                t.Fatalf("Tokenize() error = %v", err)
-                        }
-                        
-                        if len(tokens) != len(tt.expected) {
-                                t.Fatalf("Expected %d tokens, got %d", len(tt.expected), len(tokens))
-                        }
-                        
-                        for i, expectedType := range tt.expected {
-                                if tokens[i].Type != expectedType {
-                                        t.Errorf("Token %d: expected type %v, got %v", i, expectedType, tokens[i].Type)
-                                }
-                        }
-                })
-        }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lexer := NewLexer(tt.input)
+			tokens, err := lexer.Tokenize()
+			if err != nil {
+				t.Fatalf("Tokenize error: %v", err)
+			}
+			if len(tokens) != len(tt.expected) {
+				t.Fatalf("expected %d tokens, got %d", len(tt.expected), len(tokens))
+			}
+			for i, tok := range tokens {
+				if tok.Type != tt.expected[i] {
+					t.Fatalf("token %d expected %v, got %v", i, tt.expected[i], tok.Type)
+				}
+			}
+		})
+	}
 }
 
-func TestErrorHandling(t *testing.T) {
-        errorCases := []struct {
-                name  string
-                input string
-        }{
-                {
-                        name:  "no root",
-                        input: "node.value",
-                },
-                {
-                        name:  "unterminated quote",
-                        input: `$["unterminated`,
-                },
-                {
-                        name:  "unterminated group",
-                        input: "$.node.(child|value",
-                },
-                {
-                        name:  "invalid repetition",
-                        input: "$.node{*}",
-                },
-                {
-                        name:  "empty group",
-                        input: "$.node.()",
-                },
-        }
-
-        for _, tt := range errorCases {
-                t.Run(tt.name, func(t *testing.T) {
-                        _, err := ParseExpression(tt.input)
-                        if err == nil {
-                                t.Errorf("Expected error for input: %s", tt.input)
-                        }
-                        t.Logf("Got expected error: %v", err)
-                })
-        }
+func TestParseExpressionInvalidPatterns(t *testing.T) {
+	cases := []string{
+		"$[~]",
+		"$[#]",
+		"$.(child|){*}",
+		"$.node.(|child)",
+	}
+	for _, input := range cases {
+		if _, err := ParseExpression(input); err == nil {
+			t.Fatalf("expected error for %s", input)
+		}
+	}
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,553 +1,89 @@
 package main
 
 import (
-        "testing"
+	"sort"
+	"testing"
 
-        "jsonpath-sdk/json"
-        "jsonpath-sdk/parser"
-        "jsonpath-sdk/tree"
+	jsonpkg "jsonpath-sdk/json"
+	"jsonpath-sdk/parser"
+	"jsonpath-sdk/tree"
 )
 
-// TestJSONSchemaPatternMatching tests schema-path expressions against realistic JSON schemas and instance documents
-func TestJSONSchemaPatternMatching(t *testing.T) {
-        tests := []struct {
-                name           string
-                expression     string
-                jsonSchema     string
-                instanceDoc    string
-                expectedMatches []string
-                description    string
-        }{
-                {
-                        name:       "OpenAPI_Schema_Properties",
-                        expression: "$.properties.(name|description|type)",
-                        jsonSchema: `{
-                                "type": "object",
-                                "properties": {
-                                        "name": {"type": "string", "description": "User name"},
-                                        "age": {"type": "integer", "description": "User age"},
-                                        "email": {"type": "string", "format": "email"}
-                                }
-                        }`,
-                        instanceDoc: `{
-                                "name": "John Doe",
-                                "age": 30,
-                                "email": "john@example.com"
-                        }`,
-                        expectedMatches: []string{"$.properties.name", "$.properties.age.description", "$.properties.email.type"},
-                        description:     "Match OpenAPI schema property definitions",
-                },
-                {
-                        name:       "Recursive_Schema_Definition",
-                        expression: "$.definitions.Person.properties.name.type",
-                        jsonSchema: `{
-                                "definitions": {
-                                        "Person": {
-                                                "type": "object",
-                                                "properties": {
-                                                        "name": {"type": "string"},
-                                                        "children": {
-                                                                "type": "array",
-                                                                "items": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                                "name": {"type": "string"},
-                                                                                "age": {"type": "number"}
-                                                                        }
-                                                                }
-                                                        }
-                                                }
-                                        }
-                                }
-                        }`,
-                        instanceDoc: `{
-                                "name": "Parent",
-                                "children": [
-                                        {"name": "Child1", "age": 10},
-                                        {"name": "Child2", "age": 12}
-                                ]
-                        }`,
-                        expectedMatches: []string{
-                                "$.definitions.Person.properties.name.type",
-                                "$.definitions.Person.properties.children.items.properties.name.type",
-                                "$.definitions.Person.properties.children.items.properties.age.type",
-                        },
-                        description: "Handle recursive schema definitions with nested properties and arrays",
-                },
-                {
-                        name:       "API_Schema_Structure",
-                        expression: "$.paths.users.get.responses[\"200\"].schema.properties.users.type",
-                        jsonSchema: `{
-                                "paths": {
-                                        "users": {
-                                                "get": {
-                                                        "responses": {
-                                                                "200": {
-                                                                        "description": "Success",
-                                                                        "schema": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                        "users": {"type": "array"},
-                                                                                        "total": {"type": "integer"}
-                                                                                }
-                                                                        }
-                                                                },
-                                                                "400": {
-                                                                        "description": "Bad Request",
-                                                                        "schema": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                        "error": {"type": "string"},
-                                                                                        "code": {"type": "integer"}
-                                                                                }
-                                                                        }
-                                                                }
-                                                        }
-                                                },
-                                                "post": {
-                                                        "responses": {
-                                                                "201": {
-                                                                        "description": "Created",
-                                                                        "schema": {
-                                                                                "type": "object",
-                                                                                "properties": {
-                                                                                        "id": {"type": "string"},
-                                                                                        "status": {"type": "string"}
-                                                                                }
-                                                                        }
-                                                                }
-                                                        }
-                                                }
-                                        }
-                                }
-                        }`,
-                        instanceDoc: `{
-                                "users": [{"name": "Alice"}, {"name": "Bob"}],
-                                "total": 2
-                        }`,
-                        expectedMatches: []string{
-                                "$.paths./users.get.responses.200.schema.properties.users.type",
-                                "$.paths./users.get.responses.200.schema.properties.total.type",
-                                "$.paths./users.get.responses.400.schema.properties.error.type",
-                                "$.paths./users.get.responses.400.schema.properties.code.type",
-                        },
-                        description: "Navigate complex OpenAPI path structure with multiple HTTP methods and responses",
-                },
-                {
-                        name:       "Nested_Schema_Composition",
-                        expression: "$.schema.definitions.Address.type",
-                        jsonSchema: `{
-                                "schema": {
-                                        "allOf": [
-                                                {
-                                                        "type": "object",
-                                                        "properties": {
-                                                                "id": {"type": "string"},
-                                                                "created": {"type": "string", "format": "date-time"}
-                                                        }
-                                                },
-                                                {
-                                                        "type": "object",
-                                                        "properties": {
-                                                                "name": {"type": "string"},
-                                                                "metadata": {
-                                                                        "type": "object",
-                                                                        "properties": {
-                                                                                "tags": {"type": "array"},
-                                                                                "category": {"type": "string"}
-                                                                        }
-                                                                }
-                                                        }
-                                                }
-                                        ],
-                                        "definitions": {
-                                                "Address": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                                "street": {"type": "string"},
-                                                                "city": {"type": "string"}
-                                                        }
-                                                }
-                                        }
-                                }
-                        }`,
-                        instanceDoc: `{
-                                "id": "123",
-                                "name": "Test Object",
-                                "created": "2023-01-01T00:00:00Z",
-                                "metadata": {
-                                        "tags": ["test", "example"],
-                                        "category": "demo"
-                                }
-                        }`,
-                        expectedMatches: []string{
-                                "$.schema.allOf[0].properties.id.type",
-                                "$.schema.allOf[0].properties.created.type",
-                                "$.schema.allOf[1].properties.name.type",
-                                "$.schema.allOf[1].properties.metadata.properties.tags.type",
-                                "$.schema.allOf[1].properties.metadata.properties.category.type",
-                                "$.schema.definitions.Address.properties.street.type",
-                                "$.schema.definitions.Address.properties.city.type",
-                        },
-                        description: "Handle JSON Schema composition keywords (allOf, anyOf, oneOf) with nested structures",
-                },
-                {
-                        name:       "Configuration_Schema_Alternatives",
-                        expression: "$.config.database.connection.host",
-                        jsonSchema: `{
-                                "config": {
-                                        "database": {
-                                                "connection": {
-                                                        "host": "localhost",
-                                                        "port": 5432,
-                                                        "timeout": 30,
-                                                        "pool": {
-                                                                "min": 1,
-                                                                "max": 10
-                                                        }
-                                                },
-                                                "settings": {
-                                                        "ssl": true,
-                                                        "timeout": 5000
-                                                }
-                                        },
-                                        "cache": {
-                                                "connection": {
-                                                        "host": "redis-server",
-                                                        "port": 6379
-                                                },
-                                                "settings": {
-                                                        "ttl": 3600,
-                                                        "timeout": 1000
-                                                }
-                                        },
-                                        "logging": {
-                                                "settings": {
-                                                        "level": "info",
-                                                        "timeout": 500
-                                                }
-                                        }
-                                }
-                        }`,
-                        instanceDoc: `{
-                                "host": "prod-db",
-                                "port": 5432,
-                                "timeout": 30
-                        }`,
-                        expectedMatches: []string{
-                                "$.config.database.connection.host",
-                                "$.config.database.connection.port",
-                                "$.config.database.connection.timeout",
-                                "$.config.database.settings.timeout",
-                                "$.config.cache.connection.host",
-                                "$.config.cache.connection.port",
-                                "$.config.cache.settings.timeout",
-                                "$.config.logging.settings.timeout",
-                        },
-                        description: "Match configuration schemas with alternative service types and settings",
-                },
-                {
-                        name:       "Deeply_Nested_Recursive_Structure",
-                        expression: "$.organization.departments.engineering.teams.backend.leads.tech_lead.profile.email",
-                        jsonSchema: `{
-                                "organization": {
-                                        "departments": {
-                                                "engineering": {
-                                                        "teams": {
-                                                                "backend": {
-                                                                        "leads": {
-                                                                                "tech_lead": {
-                                                                                        "profile": {
-                                                                                                "name": "Alice",
-                                                                                                "email": "alice@company.com"
-                                                                                        },
-                                                                                        "contact": {
-                                                                                                "phone": "123-456-7890",
-                                                                                                "email": "alice.work@company.com"
-                                                                                        }
-                                                                                }
-                                                                        },
-                                                                        "members": {
-                                                                                "developer1": {
-                                                                                        "profile": {
-                                                                                                "name": "Bob",
-                                                                                                "email": "bob@company.com"
-                                                                                        }
-                                                                                }
-                                                                        }
-                                                                }
-                                                        }
-                                                }
-                                        },
-                                        "teams": {
-                                                "design": {
-                                                        "leads": {
-                                                                "design_lead": {
-                                                                        "contact": {
-                                                                                "email": "carol@company.com"
-                                                                        }
-                                                                }
-                                                        }
-                                                }
-                                        }
-                                }
-                        }`,
-                        instanceDoc: `{
-                                "profile": {
-                                        "name": "John Doe",
-                                        "email": "john@company.com"
-                                },
-                                "contact": {
-                                        "email": "john.work@company.com",
-                                        "phone": "555-0123"
-                                }
-                        }`,
-                        expectedMatches: []string{
-                                "$.organization.departments.engineering.teams.backend.leads.tech_lead.profile.email",
-                                "$.organization.departments.engineering.teams.backend.leads.tech_lead.contact.email",
-                                "$.organization.departments.engineering.teams.backend.members.developer1.profile.email",
-                                "$.organization.teams.design.leads.design_lead.contact.email",
-                        },
-                        description: "Navigate deeply nested organizational structures with multiple levels of recursion",
-                },
-        }
-
-        for _, tt := range tests {
-                t.Run(tt.name, func(t *testing.T) {
-                        // Parse the schema-path expression
-                        expr, err := parser.ParseExpression(tt.expression)
-                        if err != nil {
-                                t.Fatalf("Failed to parse expression '%s': %v", tt.expression, err)
-                        }
-
-                        // Build pattern tree
-                        patternTree := tree.NewPatternTree()
-                        if err := patternTree.AddPattern(expr); err != nil {
-                                t.Fatalf("Failed to build pattern tree: %v", err)
-                        }
-
-                        // Test against JSON schema
-                        processor := json.NewPathExtractor()
-                        if err := processor.ValidateJSON(tt.jsonSchema); err != nil {
-                                t.Fatalf("Invalid JSON schema: %v", err)
-                        }
-
-                        // Extract paths from schema
-                        schemaPaths, err := processor.ExtractPaths(tt.jsonSchema)
-                        if err != nil {
-                                t.Fatalf("Failed to extract paths from schema: %v", err)
-                        }
-
-                        // Find matching paths in schema
-                        var schemaMatches []string
-                        for _, path := range schemaPaths {
-                                segments := processor.ConvertPathToSegments(path)
-                                if patternTree.MatchPath(segments) {
-                                        schemaMatches = append(schemaMatches, path)
-                                }
-                        }
-
-                        // Validate that we found at least some matches
-                        if len(schemaMatches) == 0 {
-                                t.Errorf("No schema paths matched expression '%s'", tt.expression)
-                                t.Logf("Available schema paths: %v", schemaPaths)
-                        } else {
-                                t.Logf("Schema matches (%d): %v", len(schemaMatches), schemaMatches)
-                        }
-
-                        // Test against instance document if provided
-                        if tt.instanceDoc != "" {
-                                if err := processor.ValidateJSON(tt.instanceDoc); err != nil {
-                                        t.Fatalf("Invalid instance document: %v", err)
-                                }
-
-                                // Extract paths from instance document
-                                instancePaths, err := processor.ExtractPaths(tt.instanceDoc)
-                                if err != nil {
-                                        t.Fatalf("Failed to extract paths from instance document: %v", err)
-                                }
-
-                                // Find matching paths in instance
-                                var instanceMatches []string
-                                for _, path := range instancePaths {
-                                        segments := processor.ConvertPathToSegments(path)
-                                        if patternTree.MatchPath(segments) {
-                                                instanceMatches = append(instanceMatches, path)
-                                        }
-                                }
-
-                                t.Logf("Instance matches (%d): %v", len(instanceMatches), instanceMatches)
-                        }
-
-                        // Log test results
-                        t.Logf("Test: %s", tt.description)
-                        t.Logf("Expression: %s", tt.expression)
-                        t.Logf("Found %d matching paths in schema", len(schemaMatches))
-                })
-        }
+func collectMatches(t *testing.T, expression string, jsonData string) []string {
+	t.Helper()
+	expr, err := parser.ParseExpression(expression)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	patternTree := tree.NewPatternTree()
+	if err := patternTree.AddPattern(expr); err != nil {
+		t.Fatalf("add pattern error: %v", err)
+	}
+	processor := jsonpkg.NewPathExtractor()
+	paths, err := processor.ExtractPaths(jsonData)
+	if err != nil {
+		t.Fatalf("extract paths error: %v", err)
+	}
+	matches := make([]string, 0)
+	for _, path := range paths {
+		segments := processor.ConvertPathToSegments(path)
+		if patternTree.MatchSegments(segments) {
+			matches = append(matches, path)
+		}
+	}
+	sort.Strings(matches)
+	return matches
 }
 
-// TestSchemaPathComplexPatterns tests advanced schema-path pattern matching capabilities
-func TestSchemaPathComplexPatterns(t *testing.T) {
-        complexTests := []struct {
-                name           string
-                expression     string
-                jsonData       string
-                shouldMatch    bool
-                expectedCount  int
-                description    string
-        }{
-                {
-                        name:        "Simple_Nested_Path",
-                        expression:  "$.api.v1.endpoints.get.users.config",
-                        jsonData: `{
-                                "api": {
-                                        "v1": {
-                                                "endpoints": {
-                                                        "get": {
-                                                                "users": {"config": {"timeout": 30}},
-                                                                "posts": {"config": {"cache": true}}
-                                                        },
-                                                        "post": {
-                                                                "users": {"config": {"validation": true}}
-                                                        }
-                                                },
-                                                "middleware": {
-                                                        "get": {
-                                                                "auth": {"config": {"required": true}}
-                                                        }
-                                                }
-                                        },
-                                        "v2": {
-                                                "endpoints": {
-                                                        "get": {
-                                                                "users": {"config": {"timeout": 60}}
-                                                        }
-                                                }
-                                        }
-                                }
-                        }`,
-                        shouldMatch:   true,
-                        expectedCount: 1,
-                        description:   "Handle triple-nested repetition with multiple alternatives at each level",
-                },
-                {
-                        name:        "Simple_Bracket_Notation",
-                        expression:  "$.data.endpoints.v1.schema.properties.name.type",
-                        jsonData: `{
-                                "data": {
-                                        "endpoints": {
-                                                        "v1": {
-                                                                "schema": {
-                                                                        "properties": {
-                                                                                "name": {"type": "string"},
-                                                                                "id": {"type": "integer"}
-                                                                        }
-                                                                }
-                                                        }
-                                                },
-                                                "routes": {
-                                                        "v1": {
-                                                                "schema": {
-                                                                        "properties": {
-                                                                                "path": {"type": "string"},
-                                                                                "method": {"type": "string"}
-                                                                        }
-                                                                }
-                                                        }
-                                                }
-                                        }
-                                }
-                        }`,
-                        shouldMatch:   true,
-                        expectedCount: 1,
-                        description:   "Combine bracket notation with group expressions and repetition",
-                },
-                {
-                        name:        "Simple_Schema_Pattern",
-                        expression:  "$.schema.properties.user.type",
-                        jsonData: `{
-                                "schema": {
-                                        "definitions": {
-                                                "User": {
-                                                        "allOf": [
-                                                                {"type": "object", "properties": {"id": {"type": "string"}}},
-                                                                {"type": "object", "properties": {"name": {"type": "string"}}}
-                                                        ]
-                                                },
-                                                "Address": {
-                                                        "anyOf": [
-                                                                {"type": "object", "properties": {"street": {"type": "string"}}},
-                                                                {"type": "null"}
-                                                        ]
-                                                }
-                                        },
-                                        "properties": {
-                                                "user": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                                "profile": {"type": "object"}
-                                                        }
-                                                }
-                                        }
-                                }
-                        }`,
-                        shouldMatch:   true,
-                        expectedCount: 1,
-                        description:   "Match JSON Schema validation patterns with composition keywords",
-                },
-        }
+func TestSchemaRecursiveMatching(t *testing.T) {
+	jsonData := `{"node":{"value":"root","child":{"value":"direct"},"meta":{"child":{"value":"nested"}}}}`
+	matches := collectMatches(t, "$.node.(child|meta.child){*}.value", jsonData)
+	expected := []string{
+		"$.node.value",
+		"$.node.child.value",
+		"$.node.meta.child.value",
+	}
+	sort.Strings(expected)
+	if len(matches) != len(expected) {
+		t.Fatalf("expected %d matches, got %d: %v", len(expected), len(matches), matches)
+	}
+	for i, exp := range expected {
+		if matches[i] != exp {
+			t.Fatalf("expected match %s, got %s", exp, matches[i])
+		}
+	}
+}
 
-        for _, tt := range complexTests {
-                t.Run(tt.name, func(t *testing.T) {
-                        // Parse the expression
-                        expr, err := parser.ParseExpression(tt.expression)
-                        if err != nil {
-                                t.Fatalf("Failed to parse expression '%s': %v", tt.expression, err)
-                        }
+func TestSchemaWildcardRegexMatching(t *testing.T) {
+	jsonData := `{"config":{"cache-service":{"instances":[{"id":"cache-1"}]},"user-service":{"instances":[{"id":"id42"}]}}}`
+	matches := collectMatches(t, "$.config[#*service].instances[*].id", jsonData)
+	expected := []string{
+		"$.config.cache-service.instances[0].id",
+		"$.config.user-service.instances[0].id",
+	}
+	if len(matches) != len(expected) {
+		t.Fatalf("expected %d matches, got %d: %v", len(expected), len(matches), matches)
+	}
+	for i, exp := range expected {
+		if matches[i] != exp {
+			t.Fatalf("expected match %s, got %s", exp, matches[i])
+		}
+	}
+}
 
-                        // Build pattern tree
-                        patternTree := tree.NewPatternTree()
-                        if err := patternTree.AddPattern(expr); err != nil {
-                                t.Fatalf("Failed to build pattern tree: %v", err)
-                        }
-
-                        // Extract and test paths
-                        processor := json.NewPathExtractor()
-                        if err := processor.ValidateJSON(tt.jsonData); err != nil {
-                                t.Fatalf("Invalid JSON data: %v", err)
-                        }
-
-                        paths, err := processor.ExtractPaths(tt.jsonData)
-                        if err != nil {
-                                t.Fatalf("Failed to extract paths: %v", err)
-                        }
-
-                        // Count matches
-                        var matches []string
-                        for _, path := range paths {
-                                segments := processor.ConvertPathToSegments(path)
-                                if patternTree.MatchPath(segments) {
-                                        matches = append(matches, path)
-                                }
-                        }
-
-                        hasMatches := len(matches) > 0
-                        if hasMatches != tt.shouldMatch {
-                                t.Errorf("Expected match=%v, got match=%v for expression '%s'", 
-                                        tt.shouldMatch, hasMatches, tt.expression)
-                                t.Logf("All paths: %v", paths)
-                                t.Logf("Matches: %v", matches)
-                        }
-
-                        if tt.expectedCount > 0 && len(matches) != tt.expectedCount {
-                                t.Errorf("Expected %d matches, got %d matches", tt.expectedCount, len(matches))
-                                t.Logf("Matches: %v", matches)
-                        }
-
-                        t.Logf("Test: %s", tt.description)
-                        t.Logf("Expression: %s", tt.expression)
-                        t.Logf("Matches: %d - %v", len(matches), matches)
-                })
-        }
+func TestSchemaPropertyRepetition(t *testing.T) {
+	jsonData := `{"meta":{"meta":{"child":{"value":1}},"child":{"value":2}}}`
+	matches := collectMatches(t, "$.meta{*}.child.value", jsonData)
+	expected := []string{
+		"$.meta.child.value",
+		"$.meta.meta.child.value",
+	}
+	if len(matches) != len(expected) {
+		t.Fatalf("expected %d matches, got %d: %v", len(expected), len(matches), matches)
+	}
+	for i, exp := range expected {
+		if matches[i] != exp {
+			t.Fatalf("expected match %s, got %s", exp, matches[i])
+		}
+	}
 }

--- a/spec/SPECIFICATION.md
+++ b/spec/SPECIFICATION.md
@@ -1,0 +1,100 @@
+# Schema Path Expression Specification
+
+This document defines the schema-path expression language implemented by this
+project.  The language borrows the familiar `$.property` style from JSONPath and
+extends it to express recursive shapes, wildcard properties, regular-expression
+matching, and repetition of object chains.
+
+## Lexical Structure
+
+* **Root** – every expression begins with the root token `$`.
+* **Dot (`.`)** – separates object properties and group expressions.
+* **Identifiers** – property names following `[a-zA-Z_][a-zA-Z0-9_]*`.
+* **Bracket notation** – `[ ... ]` introduces special selectors:
+  * `["name"]` or `[name]` – literal property access with escaping support.
+  * `["escaped\"name"]` – uses `\` to escape quotes and brackets.
+  * `[#pattern]` – file-system style wildcard using `*`, `?`, and character
+    classes; implemented with Go's `path.Match` rules.
+  * `[~regex]` – regular-expression selector using Go's RE syntax.
+  * `[N]` – zero-based array index.
+  * `[*]` – array wildcard matching any index.
+* **Groups** – parenthesised sequences `( ... )` with alternatives separated by
+  `|`.
+* **Repetition** – `{*}` applies to the preceding group or identifier sequence,
+  denoting zero-or-more occurrences.
+
+Whitespace may appear between tokens and is ignored.
+
+## Grammar (EBNF)
+
+```
+Expression      ::= Root Path?
+Root            ::= "$"
+Path            ::= Segment*
+Segment         ::= "." SegmentItem | BracketNotation
+SegmentItem     ::= Identifier Repetition? | GroupExpression
+Identifier      ::= [a-zA-Z_][a-zA-Z0-9_]*
+BracketNotation ::= "[" BracketContent "]"
+BracketContent  ::= QuotedString | WildcardContent | RegexContent | Index | Property
+QuotedString    ::= '"' (EscapedChar | [^"\\])* '"'
+WildcardContent ::= "#" Property
+RegexContent    ::= "~" Property
+Index           ::= [0-9]+
+Property        ::= (EscapedChar | [^]\\])*
+EscapedChar     ::= "\\" .
+GroupExpression ::= "(" GroupSeq ("|" GroupSeq)* ")" Repetition?
+GroupSeq        ::= GroupPrimary ("." GroupPrimary)*
+GroupPrimary    ::= Identifier BracketSuffix? Repetition? | GroupExpression
+BracketSuffix   ::= BracketNotation+
+Repetition      ::= "{*}"
+```
+
+## Semantics
+
+* **Properties** – `$.user.name` navigates object members using identifiers.
+* **Bracket properties** – allow property names that would otherwise require
+  quoting, plus wildcard and regex matching.
+* **Array indices** – `[N]` advances into the Nth array element; `[*]` expands
+  to every element.
+* **Groups** – `(child|meta.child)` creates alternatives evaluated relative to
+  the group's entry position.  Each alternative is a sequence of AST nodes.
+* **Repetition** – `{*}` performs a Kleene star over the preceding sequence.
+  Repetition can apply both to a group and to a simple identifier chain (e.g.
+  `meta{*}` expands to zero or more `.meta` hops).
+* **Escaping** – `\` escapes the following character inside brackets, allowing
+  literal `]` or `\` to appear in property names.
+
+## Runtime Model
+
+The parser produces an abstract syntax tree composed of the following node
+types:
+
+* `PropertyNode` – `.name`
+* `BracketNode` – `[ ... ]` selectors with a discriminated union describing the
+  underlying kind (literal, wildcard, regex, array index, array wildcard)
+* `GroupNode` – group alternatives with an optional repetition flag
+* `RepetitionNode` – wrapper for identifier/bracket sequences that repeat
+
+The matcher compiles the AST into an epsilon-NFA-backed trie. Literal
+transitions are shared between patterns so multiple expressions can be matched
+simultaneously.  Repetition introduces epsilon transitions that loop back to the
+sequence entry, enabling recursive descent without materialising infinite paths.
+
+Matching operates on `spec.PathSegment` values that distinguish between property
+segments and array indices.  The JSON processor in this repository converts
+extracted document paths into these segments, allowing the trie to evaluate
+wildcards and regular expressions efficiently.
+
+## Examples
+
+* `$.node.(child|meta.child){*}.value` – matches values reachable via any number
+  of `child` hops, alternating between direct and `meta.child` edges.
+* `$.config[#*service].instances[*].id` – selects the `id` of every instance for
+  properties ending with `service`.
+* `$.meta{*}.child.value` – follows zero or more `.meta` properties before
+  selecting the final `.child.value`.
+
+The specification above is implemented by the parser and matcher provided in
+this repository.  Validation errors are raised when expressions violate the
+grammar (for example an empty group alternative, malformed regex, or missing
+closing bracket).

--- a/spec/specification.go
+++ b/spec/specification.go
@@ -1,234 +1,269 @@
 package spec
 
 /*
-JSON Path Expression Formal Specification
-=========================================
+Package spec contains the core types and grammar definition for the schema-path
+expression language. The language extends standard JSONPath style navigation
+with recursion aware grouping, repetition, wildcards, and regular-expression
+selectors.
 
-This specification defines a JSON path expression language that extends JSONPath
-with recursive structure support and advanced bracket notation.
-
-EBNF Grammar:
+EBNF Grammar
 ------------
 
+```
 Expression      ::= Root Path?
 Root            ::= "$"
 Path            ::= Segment*
 Segment         ::= "." SegmentItem | BracketNotation
-SegmentItem     ::= Identifier | GroupExpression
+SegmentItem     ::= Identifier Repetition? | GroupExpression
 Identifier      ::= [a-zA-Z_][a-zA-Z0-9_]*
 BracketNotation ::= "[" BracketContent "]"
-BracketContent  ::= QuotedString | UnquotedString
+BracketContent  ::= QuotedString | WildcardContent | RegexContent | Index | Property
 QuotedString    ::= '"' (EscapedChar | [^"\\])* '"'
-UnquotedString  ::= (EscapedChar | [^\]\\])*
+WildcardContent ::= "#" Property
+RegexContent    ::= "~" Property
+Index           ::= [0-9]+
+Property        ::= (EscapedChar | [^]\\])*
 EscapedChar     ::= "\\" .
 GroupExpression ::= "(" GroupSeq ("|" GroupSeq)* ")" Repetition?
 GroupSeq        ::= GroupPrimary ("." GroupPrimary)*
-GroupPrimary    ::= Identifier BracketSuffix? | GroupExpression
-BracketSuffix   ::= (BracketNotation)+
+GroupPrimary    ::= Identifier BracketSuffix? Repetition? | GroupExpression
+BracketSuffix   ::= BracketNotation+
 Repetition      ::= "{*}"
+```
 
-Semantic Rules:
---------------
+Semantics
+---------
 
-1. Root Expression:
-   - Every expression must start with "$" representing the root of JSON document
+* Every expression begins at the root symbol `$`.
+* Dot segments select object properties using identifier syntax.
+* Bracket notation supports:
+  - property lookups with optional quoting and escaping,
+  - file-system style wildcards prefixed with `#`,
+  - regular-expression selectors prefixed with `~`,
+  - numeric array indices, and
+  - the array wildcard `[*]`.
+* Group expressions provide alternatives separated by `|`. Each alternative is
+  a sequence of path segments relative to the group entry position.
+* `{*}` denotes zero or more repetitions. Repetition can follow either an
+  explicit group or an identifier/identifier+bracket sequence (allowing
+  expressions such as `meta{*}.child`).
+* Escaping inside brackets follows JSON rules for quoted strings and allows `]`
+  or `\` to be escaped for unquoted content.
 
-2. Property Access:
-   - ".property" accesses object property
-   - Property names follow identifier rules: [a-zA-Z_][a-zA-Z0-9_]*
+Runtime Matching
+----------------
 
-3. Bracket Notation:
-   - For Objects:
-     * X[property] - accesses property literally (property name as-is)
-     * X["quoted"] - accesses quoted property, supports escape sequences
-     * X["\"escaped"] - property name is literal `"escaped`
-   - For Arrays:
-     * Applied to every array element (homogeneous assumption)
-     * Same syntax as objects, operates on each element
+Parsing produces an abstract syntax tree (AST) which is compiled into an
+epsilon-NFA-backed trie. Literal transitions are shared allowing multiple
+expressions to be matched efficiently against JSON documents. Wildcard and
+regular-expression selectors carry the compiled pattern for fast evaluation.
 
-4. Escape Sequences:
-   - "\\" followed by any character (.) escapes that character literally
-   - In quoted strings: \" escapes quote, \\ escapes backslash
-   - In unquoted bracket content: \] escapes closing bracket, \\ escapes backslash
-   - Any character can be escaped; the escaped character is included literally
-
-5. Group Expressions:
-   - A leading "." introduces the group as a segment: .(alternative1|alternative2|...)
-   - Inside groups, each alternative is a sequence without a leading dot for the first item
-   - Identifiers can be followed by bracket notation without dots (e.g., "meta[\"child\"]") 
-   - Subsequent items within a group alternative are separated by dots
-   - Each alternative can be a sequence of multiple path segments (e.g., "meta.child")
-   - Used for representing alternative paths in recursive structures
-   - AST String() representation avoids leading dots on first item of group alternatives
-
-6. Repetition:
-   - {*} after a group means zero or more repetitions of the entire group
-   - Applies to all alternatives within the group
-   - Enables recursive structure representation
-   - Only valid after group expressions
-
-7. Bracket Notation Scope:
-   - Numeric array indices are not supported (arrays use element-wise application)
-   - Wildcard operators (*) are not supported in bracket notation
-   - Only property name literals and quoted strings are supported
-   - Group alternatives cannot start with bracket notation (must start with identifier)
-   - Multiple consecutive brackets are allowed after identifiers (e.g., meta["a"]["b"])
-
-Examples:
---------
-
-Basic Property Access:
-- $.node.value
-- $.user.name
-
-Bracket Notation:
-- $.data[property]          # literal property access
-- $.data["quoted-name"]     # quoted property access  
-- $.data["\"special"]       # property name is `"special`
-- $.array[element]          # applied to each array element
-
-Recursive Structures:
-- $.node.(child|meta.child){*}.value
-  Represents: node -> (child OR meta.child) -> repeat -> value
-  
-- $.tree.(left|right){*}.data
-  Represents: tree -> (left OR right) -> repeat -> data
-
-Group Expression Parsing:
-- $.node.(child|meta["child"]){*}.value
-  Demonstrates: identifier+bracket adjacency within group alternatives
-  
-- $.data.(items["key"]["subkey"]|nested.values){*}
-  Demonstrates: multiple brackets and mixed property access in group alternatives
-
-- $.root.(a.b["c"]|x["y"].z){*}
-  Demonstrates: complex sequences with mixed dot-separated and adjacent notation
-
-Type System Implications:
-------------------------
-
-The path expression $.node.(child|meta.child){*}.value implies:
-
-type Node struct {
-    Value interface{}           `json:"value"`
-    Child *Node                `json:"child,omitempty"`
-    Meta  *struct {
-        Child *Node            `json:"child,omitempty"`
-    } `json:"meta,omitempty"`
-}
-
-Parsing Algorithm:
------------------
-
-1. Lexical Analysis:
-   - Tokenize input into: ROOT, DOT, IDENTIFIER, LBRACKET, RBRACKET, 
-     LPAREN, RPAREN, PIPE, LBRACE, STAR, RBRACE, STRING, EOF
-   
-2. Syntactic Analysis:
-   - Recursive descent parser following EBNF grammar
-   - Build Abstract Syntax Tree (AST)
-
-3. Semantic Analysis:
-   - Validate group expressions have proper repetition syntax
-   - Check escape sequences are valid
-   - Ensure brackets are properly matched
-
-4. Tree Construction:
-   - Build trie/radix tree from AST for efficient pattern matching
-   - Handle repetition by creating cycle-aware nodes
-   - Support path expansion for testing against actual JSON paths
+The matcher operates on `PathSegment` values emitted by the JSON processor.
+`PathSegment` distinguishes between property accesses and array indices so the
+matcher can correctly apply literal, wildcard, or numeric transitions.
 */
 
-// TokenType represents the different types of tokens in the path expression
+import "strconv"
+
+// TokenType represents the different types of tokens in the path expression.
 type TokenType int
 
 const (
-        TokenEOF TokenType = iota
-        TokenRoot          // $
-        TokenDot           // .
-        TokenIdentifier    // property name
-        TokenLBracket      // [
-        TokenRBracket      // ]
-        TokenLParen        // (
-        TokenRParen        // )
-        TokenPipe          // |
-        TokenLBrace        // {
-        TokenStar          // *
-        TokenRBrace        // }
-        TokenString        // quoted or unquoted content
-        TokenInvalid
+	TokenEOF        TokenType = iota
+	TokenRoot                 // $
+	TokenDot                  // .
+	TokenIdentifier           // property name
+	TokenLParen               // (
+	TokenRParen               // )
+	TokenPipe                 // |
+	TokenStar                 // {*}
+	TokenBracket              // [content]
 )
 
-// Token represents a single token in the path expression
+// Token represents a single token in the path expression.
 type Token struct {
-        Type     TokenType
-        Value    string
-        Position int
+	Type     TokenType
+	Value    string
+	Position int
+	Quoted   bool
 }
 
-// ASTNode represents a node in the Abstract Syntax Tree
+// ASTNode represents a node in the Abstract Syntax Tree.
 type ASTNode interface {
-        String() string
+	String() string
 }
 
-// RootNode represents the $ root of the expression
+// RootNode represents the $ root of the expression.
 type RootNode struct{}
 
 func (r *RootNode) String() string { return "$" }
 
-// PropertyNode represents .property access
+// PropertyNode represents .property access.
 type PropertyNode struct {
-        Name string
+	Name string
 }
 
 func (p *PropertyNode) String() string { return "." + p.Name }
 
-// BracketNode represents [content] access
+// BracketKind enumerates the supported bracket selector modes.
+type BracketKind int
+
+const (
+	BracketProperty BracketKind = iota
+	BracketPropertyWildcard
+	BracketRegex
+	BracketArrayIndex
+	BracketArrayWildcard
+)
+
+// BracketNode represents [content] access.
 type BracketNode struct {
-        Content string
-        Quoted  bool
+	Kind   BracketKind
+	Value  string
+	Index  int
+	Quoted bool
 }
 
 func (b *BracketNode) String() string {
-        if b.Quoted {
-                return "[\"" + b.Content + "\"]"
-        }
-        return "[" + b.Content + "]"
+	switch b.Kind {
+	case BracketProperty:
+		if b.Quoted || !isIdentifier(b.Value) {
+			return "[\"" + escapeString(b.Value) + "\"]"
+		}
+		return "[" + b.Value + "]"
+	case BracketPropertyWildcard:
+		return "[#" + b.Value + "]"
+	case BracketRegex:
+		return "[~" + b.Value + "]"
+	case BracketArrayIndex:
+		return "[" + strconv.Itoa(b.Index) + "]"
+	case BracketArrayWildcard:
+		return "[*]"
+	default:
+		return "[]"
+	}
 }
 
-// GroupNode represents (expr1|expr2|...) with optional {*}
+// GroupNode represents (expr1|expr2|...) with optional repetition.
 type GroupNode struct {
-        Alternatives [][]ASTNode // Each alternative is a sequence of path segments
-        Repetition   bool        // true if followed by {*}
+	Alternatives [][]ASTNode
+	Repetition   bool
 }
 
 func (g *GroupNode) String() string {
-        result := "("
-        for i, alt := range g.Alternatives {
-                if i > 0 {
-                        result += "|"
-                }
-                for _, node := range alt {
-                        result += node.String()
-                }
-        }
-        result += ")"
-        if g.Repetition {
-                result += "{*}"
-        }
-        return result
+	result := "("
+	for i, alt := range g.Alternatives {
+		if i > 0 {
+			result += "|"
+		}
+		for j, node := range alt {
+			part := node.String()
+			if j == 0 && len(part) > 0 && part[0] == '.' {
+				result += part[1:]
+			} else {
+				result += part
+			}
+		}
+	}
+	result += ")"
+	if g.Repetition {
+		result += "{*}"
+	}
+	return result
 }
 
-// PathExpression represents the complete parsed path expression
+// RepetitionNode wraps a sequence of AST nodes that repeat with {*} semantics.
+type RepetitionNode struct {
+	Sequence []ASTNode
+}
+
+func (r *RepetitionNode) String() string {
+	result := ""
+	for i, node := range r.Sequence {
+		part := node.String()
+		if i == 0 && len(part) > 0 && part[0] == '.' {
+			result += part[1:]
+		} else {
+			result += part
+		}
+	}
+	result += "{*}"
+	return result
+}
+
+// PathExpression represents the complete parsed path expression.
 type PathExpression struct {
-        Root     *RootNode
-        Segments []ASTNode
+	Root     *RootNode
+	Segments []ASTNode
 }
 
 func (p *PathExpression) String() string {
-        result := p.Root.String()
-        for _, segment := range p.Segments {
-                result += segment.String()
-        }
-        return result
+	result := p.Root.String()
+	for _, segment := range p.Segments {
+		switch node := segment.(type) {
+		case *GroupNode, *RepetitionNode:
+			result += "." + node.String()
+		default:
+			result += node.String()
+		}
+	}
+	return result
+}
+
+// SegmentType distinguishes between property and array segments in runtime paths.
+type SegmentType int
+
+const (
+	SegmentProperty SegmentType = iota
+	SegmentArrayIndex
+)
+
+// PathSegment represents a single JSON navigation step extracted from a document.
+type PathSegment struct {
+	Type  SegmentType
+	Key   string
+	Index int
+}
+
+// NewPropertySegment constructs a property path segment.
+func NewPropertySegment(name string) PathSegment {
+	return PathSegment{Type: SegmentProperty, Key: name}
+}
+
+// NewArrayIndexSegment constructs an array index path segment.
+func NewArrayIndexSegment(index int) PathSegment {
+	return PathSegment{Type: SegmentArrayIndex, Index: index, Key: strconv.Itoa(index)}
+}
+
+func isIdentifier(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i, r := range value {
+		if i == 0 {
+			if !(r == '_' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z') {
+				return false
+			}
+			continue
+		}
+		if !(r == '_' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func escapeString(value string) string {
+	escaped := ""
+	for _, r := range value {
+		switch r {
+		case '\\':
+			escaped += "\\\\"
+		case '"':
+			escaped += "\\\""
+		default:
+			escaped += string(r)
+		}
+	}
+	return escaped
 }

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -1,433 +1,333 @@
 package tree
 
 import (
-        "fmt"
-        "strings"
+	"fmt"
+	"path"
+	"regexp"
 
-        "jsonpath-sdk/spec"
+	"jsonpath-sdk/spec"
 )
 
-// NodeType represents different types of tree nodes
-type NodeType int
-
-const (
-        NodeRoot NodeType = iota
-        NodeProperty
-        NodeBracket
-        NodeGroup
-        NodeRepetition
-)
-
-// TreeNode represents a node in the trie/radix tree
-type TreeNode struct {
-        Type         NodeType
-        Value        string  // property name or bracket content
-        Quoted       bool    // for bracket nodes, whether the content was quoted
-        Children     []*TreeNode
-        Alternatives []*TreeNode // for group nodes, represents |alternatives
-        IsRepeating  bool        // for repetition nodes, marks {*} patterns
-        IsEnd        bool        // marks valid end of a path expression
-        Parent       *TreeNode   // reference to parent node for cycle handling
+type node struct {
+	properties        map[string]*node
+	arrayIndices      map[int]*node
+	arrayWildcard     *node
+	propertyWildcards map[string]*wildcardTransition
+	regexTransitions  map[string]*regexTransition
+	epsilon           []*node
+	terminal          bool
 }
 
-// PatternTree represents the complete trie/radix tree for path patterns
+type wildcardTransition struct {
+	pattern string
+	target  *node
+}
+
+type regexTransition struct {
+	pattern string
+	expr    *regexp.Regexp
+	target  *node
+}
+
+// PatternTree stores compiled schema-path patterns as an epsilon-NFA backed trie.
 type PatternTree struct {
-        Root *TreeNode
+	root *node
 }
 
-// NewPatternTree creates a new pattern tree
+// NewPatternTree creates an empty pattern tree.
 func NewPatternTree() *PatternTree {
-        return &PatternTree{
-                Root: &TreeNode{
-                        Type:     NodeRoot,
-                        Value:    "$",
-                        Children: make([]*TreeNode, 0),
-                },
-        }
+	return &PatternTree{root: &node{}}
 }
 
-// AddPattern adds a parsed path expression to the tree
+// AddPattern compiles the given path expression into the trie.
 func (t *PatternTree) AddPattern(expr *spec.PathExpression) error {
-        current := t.Root
-        
-        // Process each segment in the expression
-        for _, segment := range expr.Segments {
-                var err error
-                current, err = t.addSegment(current, segment)
-                if err != nil {
-                        return err
-                }
-        }
-        
-        // Mark this as a valid endpoint
-        // Special handling: if the last segment was a group, mark the last group as end
-        if len(expr.Segments) > 0 {
-                lastSegment := expr.Segments[len(expr.Segments)-1]
-                if _, ok := lastSegment.(*spec.GroupNode); ok {
-                        // Find the last group node in current's children and mark it as end
-                        for i := len(current.Children) - 1; i >= 0; i-- {
-                                child := current.Children[i]
-                                if child.Type == NodeGroup {
-                                        child.IsEnd = true
-                                        break
-                                }
-                        }
-                }
-        }
-        current.IsEnd = true
-        return nil
+	if expr == nil || expr.Root == nil {
+		return fmt.Errorf("expression is nil")
+	}
+	endNodes, err := t.addSegments([]*node{t.root}, expr.Segments)
+	if err != nil {
+		return err
+	}
+	for _, n := range endNodes {
+		n.terminal = true
+	}
+	return nil
 }
 
-// addSegment adds a single segment to the tree from the current node
-func (t *PatternTree) addSegment(current *TreeNode, segment spec.ASTNode) (*TreeNode, error) {
-        switch node := segment.(type) {
-        case *spec.PropertyNode:
-                return t.addPropertyNode(current, node)
-                
-        case *spec.BracketNode:
-                return t.addBracketNode(current, node)
-                
-        case *spec.GroupNode:
-                return t.addGroupNode(current, node)
-                
-        default:
-                return nil, fmt.Errorf("unsupported AST node type: %T", segment)
-        }
+func (t *PatternTree) addSegments(starts []*node, segments []spec.ASTNode) ([]*node, error) {
+	current := epsilonClosure(starts)
+	for _, segment := range segments {
+		next, err := t.applySegment(current, segment)
+		if err != nil {
+			return nil, err
+		}
+		current = epsilonClosure(next)
+	}
+	return current, nil
 }
 
-// addPropertyNode adds a property node to the tree
-func (t *PatternTree) addPropertyNode(current *TreeNode, prop *spec.PropertyNode) (*TreeNode, error) {
-        // Look for existing property child with same name
-        for _, child := range current.Children {
-                if child.Type == NodeProperty && child.Value == prop.Name {
-                        return child, nil
-                }
-        }
-        
-        // Create new property node
-        propNode := &TreeNode{
-                Type:     NodeProperty,
-                Value:    prop.Name,
-                Children: make([]*TreeNode, 0),
-                Parent:   current,
-        }
-        
-        current.Children = append(current.Children, propNode)
-        return propNode, nil
+func (t *PatternTree) applySegment(starts []*node, segment spec.ASTNode) ([]*node, error) {
+	switch node := segment.(type) {
+	case *spec.PropertyNode:
+		return t.applyProperty(starts, node.Name), nil
+	case *spec.BracketNode:
+		return t.applyBracket(starts, node)
+	case *spec.GroupNode:
+		return t.applyGroup(starts, node)
+	case *spec.RepetitionNode:
+		return t.applyRepetition(starts, node)
+	default:
+		return nil, fmt.Errorf("unsupported AST node %T", segment)
+	}
 }
 
-// addBracketNode adds a bracket notation node to the tree
-func (t *PatternTree) addBracketNode(current *TreeNode, bracket *spec.BracketNode) (*TreeNode, error) {
-        // Look for existing bracket child with same content and quoting
-        for _, child := range current.Children {
-                if child.Type == NodeBracket && child.Value == bracket.Content && child.Quoted == bracket.Quoted {
-                        return child, nil
-                }
-        }
-        
-        // Create new bracket node
-        bracketNode := &TreeNode{
-                Type:     NodeBracket,
-                Value:    bracket.Content,
-                Quoted:   bracket.Quoted,
-                Children: make([]*TreeNode, 0),
-                Parent:   current,
-        }
-        
-        current.Children = append(current.Children, bracketNode)
-        return bracketNode, nil
+func (t *PatternTree) applyProperty(starts []*node, name string) []*node {
+	result := make([]*node, 0, len(starts))
+	for _, start := range starts {
+		child := start.ensureProperty(name)
+		result = append(result, child)
+	}
+	return uniqueNodes(result)
 }
 
-// addGroupNode adds a group node with alternatives and optional repetition
-func (t *PatternTree) addGroupNode(current *TreeNode, group *spec.GroupNode) (*TreeNode, error) {
-        // Create group node
-        groupNode := &TreeNode{
-                Type:         NodeGroup,
-                IsRepeating:  group.Repetition,
-                Alternatives: make([]*TreeNode, 0),
-                Children:     make([]*TreeNode, 0),
-                Parent:       current,
-        }
-        
-        // Process each alternative in the group
-        for _, alternative := range group.Alternatives {
-                altRoot := &TreeNode{
-                        Type:     NodeRoot, // temporary root for alternative
-                        Children: make([]*TreeNode, 0),
-                        Parent:   groupNode,
-                }
-                
-                // Build tree for this alternative
-                currentAlt := altRoot
-                for _, altSegment := range alternative {
-                        var err error
-                        currentAlt, err = t.addSegment(currentAlt, altSegment)
-                        if err != nil {
-                                return nil, err
-                        }
-                }
-                currentAlt.IsEnd = true
-                
-                // Add the alternative tree to the group
-                groupNode.Alternatives = append(groupNode.Alternatives, altRoot)
-        }
-        
-        current.Children = append(current.Children, groupNode)
-        
-        // Return the parent so subsequent segments become siblings of the group
-        return current, nil
+func (t *PatternTree) applyBracket(starts []*node, bracket *spec.BracketNode) ([]*node, error) {
+	result := make([]*node, 0, len(starts))
+	for _, start := range starts {
+		var child *node
+		var err error
+		switch bracket.Kind {
+		case spec.BracketProperty:
+			child = start.ensureProperty(bracket.Value)
+		case spec.BracketPropertyWildcard:
+			child, err = start.ensureWildcard(bracket.Value)
+		case spec.BracketRegex:
+			child, err = start.ensureRegex(bracket.Value)
+		case spec.BracketArrayIndex:
+			child = start.ensureArrayIndex(bracket.Index)
+		case spec.BracketArrayWildcard:
+			child = start.ensureArrayWildcard()
+		default:
+			err = fmt.Errorf("unknown bracket kind %v", bracket.Kind)
+		}
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, child)
+	}
+	return uniqueNodes(result), nil
 }
 
-// MatchPath tests if a given JSON path matches any pattern in the tree
-func (t *PatternTree) MatchPath(jsonPath []string) bool {
-        return t.matchFromNode(t.Root, jsonPath, 0)
+func (t *PatternTree) applyGroup(starts []*node, group *spec.GroupNode) ([]*node, error) {
+	if len(group.Alternatives) == 0 {
+		return nil, fmt.Errorf("group must contain at least one alternative")
+	}
+	if group.Repetition {
+		return t.applyRepeatingGroup(starts, group.Alternatives)
+	}
+	aggregate := make([]*node, 0)
+	for _, alt := range group.Alternatives {
+		altEnds, err := t.addSegments(starts, alt)
+		if err != nil {
+			return nil, err
+		}
+		aggregate = append(aggregate, altEnds...)
+	}
+	return uniqueNodes(aggregate), nil
 }
 
-// matchFromNode recursively matches path segments from a given node
-func (t *PatternTree) matchFromNode(node *TreeNode, path []string, pathIndex int) bool {
-        // If we've consumed all path segments, check if we're at a valid end
-        if pathIndex >= len(path) {
-                return node.IsEnd
-        }
-        
-        currentSegment := path[pathIndex]
-        
-        // Check all children of current node
-        for _, child := range node.Children {
-                switch child.Type {
-                case NodeProperty:
-                        if child.Value == currentSegment {
-                                if t.matchFromNode(child, path, pathIndex+1) {
-                                        return true
-                                }
-                        }
-                        
-                case NodeBracket:
-                        // For bracket nodes, we match against the segment directly
-                        // In real JSON path evaluation, this would be more complex
-                        if t.matchBracketSegment(child, currentSegment) {
-                                if t.matchFromNode(child, path, pathIndex+1) {
-                                        return true
-                                }
-                        }
-                        
-                case NodeGroup:
-                        if t.matchGroupNode(child, path, pathIndex) {
-                                return true
-                        }
-                        
-                }
-        }
-        
-        return false
+func (t *PatternTree) applyRepeatingGroup(starts []*node, alternatives [][]spec.ASTNode) ([]*node, error) {
+	for _, alt := range alternatives {
+		if len(alt) == 0 {
+			return nil, fmt.Errorf("repeating group alternative cannot be empty")
+		}
+	}
+	result := make([]*node, 0, len(starts))
+	result = append(result, starts...)
+	for _, start := range starts {
+		for _, alt := range alternatives {
+			altEnds, err := t.addSegments([]*node{start}, alt)
+			if err != nil {
+				return nil, err
+			}
+			for _, end := range altEnds {
+				end.addEpsilon(start)
+			}
+			result = append(result, altEnds...)
+		}
+	}
+	return uniqueNodes(result), nil
 }
 
-// matchBracketSegment matches a bracket pattern against a path segment
-func (t *PatternTree) matchBracketSegment(node *TreeNode, segment string) bool {
-        // For simplicity, we do literal string matching
-        // In a full implementation, this would handle property name resolution
-        if node.Quoted {
-                // Quoted bracket content should match exactly
-                return node.Value == segment
-        } else {
-                // Unquoted bracket content matches as property name
-                return node.Value == segment
-        }
+func (t *PatternTree) applyRepetition(starts []*node, repetition *spec.RepetitionNode) ([]*node, error) {
+	if len(repetition.Sequence) == 0 {
+		return nil, fmt.Errorf("repetition sequence cannot be empty")
+	}
+	result := make([]*node, 0, len(starts))
+	result = append(result, starts...)
+	for _, start := range starts {
+		seqEnds, err := t.addSegments([]*node{start}, repetition.Sequence)
+		if err != nil {
+			return nil, err
+		}
+		for _, end := range seqEnds {
+			end.addEpsilon(start)
+		}
+		result = append(result, seqEnds...)
+	}
+	return uniqueNodes(result), nil
 }
 
-// matchGroupNode matches a group node with alternatives
-func (t *PatternTree) matchGroupNode(groupNode *TreeNode, path []string, pathIndex int) bool {
-        if groupNode.IsRepeating {
-                // For repeating groups, try 0 or more iterations
-                return t.matchRepeatingGroup(groupNode, path, pathIndex)
-        } else {
-                // For non-repeating groups, match one alternative then continue with siblings
-                return t.matchNonRepeatingGroup(groupNode, path, pathIndex)
-        }
+// MatchSegments checks whether the provided runtime path matches any pattern.
+func (t *PatternTree) MatchSegments(segments []spec.PathSegment) bool {
+	current := epsilonClosure([]*node{t.root})
+	for _, segment := range segments {
+		nextSet := make(map[*node]struct{})
+		for _, state := range current {
+			switch segment.Type {
+			case spec.SegmentProperty:
+				if child, ok := state.properties[segment.Key]; ok {
+					nextSet[child] = struct{}{}
+				}
+				for _, trans := range state.propertyWildcards {
+					if match, _ := path.Match(trans.pattern, segment.Key); match {
+						nextSet[trans.target] = struct{}{}
+					}
+				}
+				for _, trans := range state.regexTransitions {
+					if trans.expr.MatchString(segment.Key) {
+						nextSet[trans.target] = struct{}{}
+					}
+				}
+			case spec.SegmentArrayIndex:
+				if child, ok := state.arrayIndices[segment.Index]; ok {
+					nextSet[child] = struct{}{}
+				}
+				if state.arrayWildcard != nil {
+					nextSet[state.arrayWildcard] = struct{}{}
+				}
+			}
+		}
+		if len(nextSet) == 0 {
+			return false
+		}
+		next := make([]*node, 0, len(nextSet))
+		for n := range nextSet {
+			next = append(next, n)
+		}
+		current = epsilonClosure(next)
+		if len(current) == 0 {
+			return false
+		}
+	}
+	for _, state := range current {
+		if state.terminal {
+			return true
+		}
+	}
+	return false
 }
 
-// matchNonRepeatingGroup matches a non-repeating group and continues with siblings
-func (t *PatternTree) matchNonRepeatingGroup(groupNode *TreeNode, path []string, pathIndex int) bool {
-        // Try each alternative
-        for _, alternative := range groupNode.Alternatives {
-                currentIndex := pathIndex
-                if t.matchAlternativeSegments(alternative, path, &currentIndex) {
-                        // After matching alternative, continue with next sibling of the group
-                        return t.continueAfterGroup(groupNode, path, currentIndex)
-                }
-        }
-        return false
+func (n *node) ensureProperty(name string) *node {
+	if n.properties == nil {
+		n.properties = make(map[string]*node)
+	}
+	child, ok := n.properties[name]
+	if !ok {
+		child = &node{}
+		n.properties[name] = child
+	}
+	return child
 }
 
-// matchRepeatingGroup handles repetition logic
-func (t *PatternTree) matchRepeatingGroup(groupNode *TreeNode, path []string, pathIndex int) bool {
-        // First, try zero iterations (go directly to what comes after the group)
-        if t.continueAfterGroup(groupNode, path, pathIndex) {
-                return true
-        }
-        
-        // Try one or more iterations
-        for _, alternative := range groupNode.Alternatives {
-                currentIndex := pathIndex
-                if t.matchAlternativeSegments(alternative, path, &currentIndex) {
-                        // After one iteration, recursively try more iterations or continue after group
-                        if t.matchRepeatingGroup(groupNode, path, currentIndex) {
-                                return true
-                        }
-                }
-        }
-        
-        return false
+func (n *node) ensureArrayIndex(index int) *node {
+	if n.arrayIndices == nil {
+		n.arrayIndices = make(map[int]*node)
+	}
+	child, ok := n.arrayIndices[index]
+	if !ok {
+		child = &node{}
+		n.arrayIndices[index] = child
+	}
+	return child
 }
 
-// continueAfterGroup continues matching after a group node (siblings)
-func (t *PatternTree) continueAfterGroup(groupNode *TreeNode, path []string, pathIndex int) bool {
-        // First check if path is exhausted
-        if pathIndex >= len(path) {
-                return groupNode.IsEnd || (groupNode.Parent != nil && groupNode.Parent.IsEnd)
-        }
-        
-        if groupNode.Parent == nil {
-                return false
-        }
-        
-        parent := groupNode.Parent
-        currentSegment := path[pathIndex]
-        
-        // Find the group's position and try all siblings after it
-        for i, child := range parent.Children {
-                if child == groupNode {
-                        // Try all siblings after the group
-                        for j := i + 1; j < len(parent.Children); j++ {
-                                sibling := parent.Children[j]
-                                
-                                switch sibling.Type {
-                                case NodeProperty:
-                                        if sibling.Value == currentSegment {
-                                                if t.matchFromNode(sibling, path, pathIndex+1) {
-                                                        return true
-                                                }
-                                        }
-                                case NodeBracket:
-                                        if t.matchBracketSegment(sibling, currentSegment) {
-                                                if t.matchFromNode(sibling, path, pathIndex+1) {
-                                                        return true
-                                                }
-                                        }
-                                case NodeGroup:
-                                        if t.matchGroupNode(sibling, path, pathIndex) {
-                                                return true
-                                        }
-                                }
-                        }
-                        break
-                }
-        }
-        
-        return false
+func (n *node) ensureArrayWildcard() *node {
+	if n.arrayWildcard == nil {
+		n.arrayWildcard = &node{}
+	}
+	return n.arrayWildcard
 }
 
-// matchAlternativeSegments matches the segments within an alternative using backtracking
-func (t *PatternTree) matchAlternativeSegments(node *TreeNode, path []string, pathIndex *int) bool {
-        if node.Type == NodeRoot {
-                // For root nodes, try matching from this position with DFS
-                return t.matchAlternativeDFS(node, path, *pathIndex, pathIndex)
-        }
-        
-        // Match single segment
-        if *pathIndex >= len(path) {
-                return false
-        }
-        
-        segment := path[*pathIndex]
-        matched := false
-        
-        switch node.Type {
-        case NodeProperty:
-                matched = (node.Value == segment)
-        case NodeBracket:
-                matched = t.matchBracketSegment(node, segment)
-        }
-        
-        if matched {
-                (*pathIndex)++
-                // Continue with children using DFS
-                return t.matchAlternativeDFS(node, path, *pathIndex, pathIndex)
-        }
-        
-        return false
+func (n *node) ensureWildcard(pattern string) (*node, error) {
+	if _, err := path.Match(pattern, pattern); err != nil {
+		return nil, fmt.Errorf("invalid wildcard pattern %q: %w", pattern, err)
+	}
+	if n.propertyWildcards == nil {
+		n.propertyWildcards = make(map[string]*wildcardTransition)
+	}
+	if trans, ok := n.propertyWildcards[pattern]; ok {
+		return trans.target, nil
+	}
+	child := &node{}
+	n.propertyWildcards[pattern] = &wildcardTransition{pattern: pattern, target: child}
+	return child, nil
 }
 
-// matchAlternativeDFS performs depth-first search on alternative tree with backtracking
-func (t *PatternTree) matchAlternativeDFS(node *TreeNode, path []string, currentIndex int, pathIndex *int) bool {
-        // If no children, we've successfully matched this branch
-        if len(node.Children) == 0 {
-                *pathIndex = currentIndex
-                return true
-        }
-        
-        // Try each child path independently with backtracking
-        for _, child := range node.Children {
-                // Save current position for backtracking
-                savedIndex := currentIndex
-                
-                // Try matching this child path
-                tempIndex := savedIndex
-                if t.matchAlternativeSegments(child, path, &tempIndex) {
-                        *pathIndex = tempIndex
-                        return true
-                }
-                
-                // Backtrack - tempIndex is automatically reset by the recursive call failure
-        }
-        
-        return false
+func (n *node) ensureRegex(pattern string) (*node, error) {
+	if n.regexTransitions == nil {
+		n.regexTransitions = make(map[string]*regexTransition)
+	}
+	if trans, ok := n.regexTransitions[pattern]; ok {
+		return trans.target, nil
+	}
+	expr, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex pattern %q: %w", pattern, err)
+	}
+	child := &node{}
+	n.regexTransitions[pattern] = &regexTransition{pattern: pattern, expr: expr, target: child}
+	return child, nil
 }
 
-
-
-// String returns a string representation of the tree for debugging
-func (t *PatternTree) String() string {
-        var sb strings.Builder
-        t.printNode(&sb, t.Root, 0)
-        return sb.String()
+func (n *node) addEpsilon(target *node) {
+	for _, existing := range n.epsilon {
+		if existing == target {
+			return
+		}
+	}
+	n.epsilon = append(n.epsilon, target)
 }
 
-// printNode recursively prints tree structure
-func (t *PatternTree) printNode(sb *strings.Builder, node *TreeNode, depth int) {
-        indent := strings.Repeat("  ", depth)
-        
-        switch node.Type {
-        case NodeRoot:
-                sb.WriteString(fmt.Sprintf("%s$ (ROOT)\n", indent))
-        case NodeProperty:
-                sb.WriteString(fmt.Sprintf("%s.%s\n", indent, node.Value))
-        case NodeBracket:
-                if node.Quoted {
-                        sb.WriteString(fmt.Sprintf("%s[\"%s\"]\n", indent, node.Value))
-                } else {
-                        sb.WriteString(fmt.Sprintf("%s[%s]\n", indent, node.Value))
-                }
-        case NodeGroup:
-                sb.WriteString(fmt.Sprintf("%s(GROUP", indent))
-                if node.IsRepeating {
-                        sb.WriteString(" {*}")
-                }
-                sb.WriteString(")\n")
-                
-                for i, alt := range node.Alternatives {
-                        sb.WriteString(fmt.Sprintf("%s  ALT%d:\n", indent, i))
-                        t.printNode(sb, alt, depth+2)
-                }
-        case NodeRepetition:
-                sb.WriteString(fmt.Sprintf("%s{*} REPETITION\n", indent))
-        }
-        
-        if node.IsEnd {
-                sb.WriteString(fmt.Sprintf("%s  (END)\n", indent))
-        }
-        
-        for _, child := range node.Children {
-                t.printNode(sb, child, depth+1)
-        }
+func epsilonClosure(nodes []*node) []*node {
+	stack := make([]*node, len(nodes))
+	copy(stack, nodes)
+	visited := make(map[*node]struct{}, len(nodes))
+	for _, n := range nodes {
+		visited[n] = struct{}{}
+	}
+	result := make([]*node, 0, len(nodes))
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		result = append(result, n)
+		for _, next := range n.epsilon {
+			if _, seen := visited[next]; !seen {
+				visited[next] = struct{}{}
+				stack = append(stack, next)
+			}
+		}
+	}
+	return result
+}
+
+func uniqueNodes(nodes []*node) []*node {
+	seen := make(map[*node]struct{}, len(nodes))
+	result := make([]*node, 0, len(nodes))
+	for _, n := range nodes {
+		if _, ok := seen[n]; !ok {
+			seen[n] = struct{}{}
+			result = append(result, n)
+		}
+	}
+	return result
 }

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -1,408 +1,173 @@
 package tree
 
 import (
-        "testing"
+	"testing"
 
-        "jsonpath-sdk/parser"
+	jsonpkg "jsonpath-sdk/json"
+	"jsonpath-sdk/parser"
+	"jsonpath-sdk/spec"
 )
 
-func TestPatternTreeBasicOperations(t *testing.T) {
-        tree := NewPatternTree()
-        
-        // Test basic tree structure
-        if tree.Root == nil {
-                t.Error("Expected root node, got nil")
-        }
-        
-        if tree.Root.Type != NodeRoot {
-                t.Errorf("Expected root type, got %v", tree.Root.Type)
-        }
+func TestPatternTreeLiteralMatching(t *testing.T) {
+	expr, err := parser.ParseExpression("$.user.name")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	tree := NewPatternTree()
+	if err := tree.AddPattern(expr); err != nil {
+		t.Fatalf("add pattern error: %v", err)
+	}
+	if !tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("user"), spec.NewPropertySegment("name")}) {
+		t.Fatalf("expected literal path to match")
+	}
+	if tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("user"), spec.NewPropertySegment("age")}) {
+		t.Fatalf("unexpected match for user.age")
+	}
 }
 
-func TestAddBasicPattern(t *testing.T) {
-        tests := []struct {
-                name       string
-                expression string
-        }{
-                {"simple property", "$.node"},
-                {"nested properties", "$.node.child.value"},
-                {"bracket notation", `$["property"]`},
-                {"mixed notation", `$.node["child"].value`},
-        }
-
-        for _, tt := range tests {
-                t.Run(tt.name, func(t *testing.T) {
-                        tree := NewPatternTree()
-                        
-                        // Parse the expression
-                        expr, err := parser.ParseExpression(tt.expression)
-                        if err != nil {
-                                t.Fatalf("Failed to parse expression %s: %v", tt.expression, err)
-                        }
-                        
-                        // Add to tree
-                        err = tree.AddPattern(expr)
-                        if err != nil {
-                                t.Fatalf("Failed to add pattern %s: %v", tt.expression, err)
-                        }
-                        
-                        // Verify tree is not empty
-                        if len(tree.Root.Children) == 0 {
-                                t.Error("Expected tree to have children after adding pattern")
-                        }
-                })
-        }
+func TestPatternTreeBracketMatching(t *testing.T) {
+	expr, err := parser.ParseExpression(`$.data["prop"].value`)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	tree := NewPatternTree()
+	if err := tree.AddPattern(expr); err != nil {
+		t.Fatalf("add pattern error: %v", err)
+	}
+	path := []spec.PathSegment{spec.NewPropertySegment("data"), spec.NewPropertySegment("prop"), spec.NewPropertySegment("value")}
+	if !tree.MatchSegments(path) {
+		t.Fatalf("expected bracket property to match")
+	}
 }
 
-func TestAddGroupPattern(t *testing.T) {
-        tree := NewPatternTree()
-        
-        // Parse a group expression
-        expr, err := parser.ParseExpression("$.node.(child|value)")
-        if err != nil {
-                t.Fatalf("Failed to parse group expression: %v", err)
-        }
-        
-        // Add to tree
-        err = tree.AddPattern(expr)
-        if err != nil {
-                t.Fatalf("Failed to add group pattern: %v", err)
-        }
-        
-        // Verify tree structure
-        if len(tree.Root.Children) == 0 {
-                t.Error("Expected tree to have children")
-        }
-        
-        // Should have a property node for "node"
-        nodeChild := tree.Root.Children[0]
-        if nodeChild.Type != NodeProperty || nodeChild.Value != "node" {
-                t.Errorf("Expected property node 'node', got type %v value %s", nodeChild.Type, nodeChild.Value)
-        }
-        
-        // Should have a group node under "node"
-        if len(nodeChild.Children) == 0 {
-                t.Error("Expected 'node' to have children")
-        }
-        
-        groupChild := nodeChild.Children[0]
-        if groupChild.Type != NodeGroup {
-                t.Errorf("Expected group node, got type %v", groupChild.Type)
-        }
-        
-        // Group should have alternatives
-        if len(groupChild.Alternatives) != 2 {
-                t.Errorf("Expected 2 alternatives, got %d", len(groupChild.Alternatives))
-        }
+func TestPatternTreeWildcardAndRegex(t *testing.T) {
+	expr, err := parser.ParseExpression(`$.data[#user*][~^id\\d+$]`)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	tree := NewPatternTree()
+	if err := tree.AddPattern(expr); err != nil {
+		t.Fatalf("add pattern error: %v", err)
+	}
+	if !tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("data"), spec.NewPropertySegment("userA"), spec.NewPropertySegment("id42")}) {
+		t.Fatalf("expected wildcard/regex path to match")
+	}
+	if tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("data"), spec.NewPropertySegment("admin"), spec.NewPropertySegment("id42")}) {
+		t.Fatalf("unexpected match for admin path")
+	}
 }
 
-func TestMatchBasicPaths(t *testing.T) {
-        tree := NewPatternTree()
-        
-        // Add patterns
-        patterns := []string{
-                "$.user.name",
-                "$.user.email", 
-                `$.data["key"]`,
-        }
-        
-        for _, pattern := range patterns {
-                expr, err := parser.ParseExpression(pattern)
-                if err != nil {
-                        t.Fatalf("Failed to parse pattern %s: %v", pattern, err)
-                }
-                err = tree.AddPattern(expr)
-                if err != nil {
-                        t.Fatalf("Failed to add pattern %s: %v", pattern, err)
-                }
-        }
-        
-        // Test matching paths
-        testCases := []struct {
-                path     []string
-                expected bool
-                name     string
-        }{
-                {[]string{"user", "name"}, true, "user.name should match"},
-                {[]string{"user", "email"}, true, "user.email should match"},
-                {[]string{"data", "key"}, true, "data[key] should match"},
-                {[]string{"user", "age"}, false, "user.age should not match"},
-                {[]string{"other", "value"}, false, "other.value should not match"},
-                {[]string{"user"}, false, "incomplete path should not match"},
-        }
-        
-        for _, tc := range testCases {
-                t.Run(tc.name, func(t *testing.T) {
-                        result := tree.MatchPath(tc.path)
-                        if result != tc.expected {
-                                t.Errorf("MatchPath(%v) = %v, expected %v", tc.path, result, tc.expected)
-                        }
-                })
-        }
+func TestPatternTreeArrayMatching(t *testing.T) {
+	expr, err := parser.ParseExpression("$.items[*].value")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	tree := NewPatternTree()
+	if err := tree.AddPattern(expr); err != nil {
+		t.Fatalf("add pattern error: %v", err)
+	}
+	if !tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("items"), spec.NewArrayIndexSegment(3), spec.NewPropertySegment("value")}) {
+		t.Fatalf("expected wildcard array match")
+	}
+	if tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("items"), spec.NewPropertySegment("value")}) {
+		t.Fatalf("unexpected match for missing index")
+	}
 }
 
-func TestMatchGroupPaths(t *testing.T) {
-        tree := NewPatternTree()
-        
-        // Add a group pattern
-        expr, err := parser.ParseExpression("$.node.(child|value)")
-        if err != nil {
-                t.Fatalf("Failed to parse group pattern: %v", err)
-        }
-        err = tree.AddPattern(expr)
-        if err != nil {
-                t.Fatalf("Failed to add group pattern: %v", err)
-        }
-        
-        // Test matching
-        testCases := []struct {
-                path     []string
-                expected bool
-                name     string
-        }{
-                {[]string{"node", "child"}, true, "node.child should match"},
-                {[]string{"node", "value"}, true, "node.value should match"},
-                {[]string{"node", "other"}, false, "node.other should not match"},
-                {[]string{"other", "child"}, false, "other.child should not match"},
-        }
-        
-        for _, tc := range testCases {
-                t.Run(tc.name, func(t *testing.T) {
-                        result := tree.MatchPath(tc.path)
-                        if result != tc.expected {
-                                t.Errorf("MatchPath(%v) = %v, expected %v", tc.path, result, tc.expected)
-                        }
-                })
-        }
+func TestPatternTreeGroupRepetition(t *testing.T) {
+	expr, err := parser.ParseExpression("$.node.(child|meta.child){*}.value")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	tree := NewPatternTree()
+	if err := tree.AddPattern(expr); err != nil {
+		t.Fatalf("add pattern error: %v", err)
+	}
+	// Zero iterations
+	if !tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("node"), spec.NewPropertySegment("value")}) {
+		t.Fatalf("expected zero-iteration match")
+	}
+	// Single child
+	if !tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("node"), spec.NewPropertySegment("child"), spec.NewPropertySegment("value")}) {
+		t.Fatalf("expected single child match")
+	}
+	// Mixed alternatives
+	path := []spec.PathSegment{
+		spec.NewPropertySegment("node"),
+		spec.NewPropertySegment("meta"),
+		spec.NewPropertySegment("child"),
+		spec.NewPropertySegment("child"),
+		spec.NewPropertySegment("value"),
+	}
+	if !tree.MatchSegments(path) {
+		t.Fatalf("expected mixed alternative match")
+	}
 }
 
-func TestTreeStringRepresentation(t *testing.T) {
-        tree := NewPatternTree()
-        
-        // Add a simple pattern
-        expr, err := parser.ParseExpression("$.node.child")
-        if err != nil {
-                t.Fatalf("Failed to parse expression: %v", err)
-        }
-        
-        err = tree.AddPattern(expr)
-        if err != nil {
-                t.Fatalf("Failed to add pattern: %v", err)
-        }
-        
-        // Get string representation
-        result := tree.String()
-        if result == "" {
-                t.Error("Expected non-empty string representation")
-        }
-        
-        t.Logf("Tree string representation:\n%s", result)
+func TestPatternTreePropertyRepetition(t *testing.T) {
+	expr, err := parser.ParseExpression("$.meta{*}.child")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	tree := NewPatternTree()
+	if err := tree.AddPattern(expr); err != nil {
+		t.Fatalf("add pattern error: %v", err)
+	}
+	if !tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("child")}) {
+		t.Fatalf("expected zero meta match")
+	}
+	if !tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("meta"), spec.NewPropertySegment("child")}) {
+		t.Fatalf("expected single meta match")
+	}
+	if !tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("meta"), spec.NewPropertySegment("meta"), spec.NewPropertySegment("child")}) {
+		t.Fatalf("expected repeated meta match")
+	}
 }
 
-func TestComplexGroupWithRepetition(t *testing.T) {
-        tree := NewPatternTree()
-        
-        // Add the complex recursive pattern from the specification
-        expr, err := parser.ParseExpression("$.node.(child|meta.child){*}.value")
-        if err != nil {
-                t.Fatalf("Failed to parse complex pattern: %v", err)
-        }
-        
-        err = tree.AddPattern(expr)
-        if err != nil {
-                t.Fatalf("Failed to add complex pattern: %v", err)
-        }
-        
-        // Verify the tree structure
-        treeStr := tree.String()
-        if treeStr == "" {
-                t.Error("Expected non-empty tree representation")
-        }
-        
-        t.Logf("Complex tree structure:\n%s", treeStr)
-        
-        // Basic structure validation
-        if len(tree.Root.Children) == 0 {
-                t.Error("Expected tree to have children")
-        }
+func TestPatternTreeMultiplePatterns(t *testing.T) {
+	tree := NewPatternTree()
+	patterns := []string{"$.user.name", "$.user.email", "$.orders[*].id"}
+	for _, p := range patterns {
+		expr, err := parser.ParseExpression(p)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := tree.AddPattern(expr); err != nil {
+			t.Fatalf("add pattern error: %v", err)
+		}
+	}
+	if !tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("user"), spec.NewPropertySegment("email")}) {
+		t.Fatalf("expected user.email to match")
+	}
+	if !tree.MatchSegments([]spec.PathSegment{spec.NewPropertySegment("orders"), spec.NewArrayIndexSegment(2), spec.NewPropertySegment("id")}) {
+		t.Fatalf("expected orders[*].id to match")
+	}
 }
 
-func TestBracketPatternMatching(t *testing.T) {
-        tree := NewPatternTree()
-        
-        // Add bracket patterns
-        patterns := []string{
-                `$["quoted-key"]`,
-                `$[unquoted]`,
-                `$.node["child"]`,
-        }
-        
-        for _, pattern := range patterns {
-                expr, err := parser.ParseExpression(pattern)
-                if err != nil {
-                        t.Fatalf("Failed to parse pattern %s: %v", pattern, err)
-                }
-                err = tree.AddPattern(expr)
-                if err != nil {
-                        t.Fatalf("Failed to add pattern %s: %v", pattern, err)
-                }
-        }
-        
-        // Test basic bracket matching
-        testCases := []struct {
-                path     []string
-                expected bool
-                name     string
-        }{
-                {[]string{"quoted-key"}, true, "quoted key should match"},
-                {[]string{"unquoted"}, true, "unquoted key should match"},
-                {[]string{"node", "child"}, true, "node.child bracket should match"},
-                {[]string{"node", "other"}, false, "node.other should not match"},
-                {[]string{"wrong"}, false, "wrong key should not match"},
-        }
-        
-        for _, tc := range testCases {
-                t.Run(tc.name, func(t *testing.T) {
-                        result := tree.MatchPath(tc.path)
-                        if result != tc.expected {
-                                t.Errorf("MatchPath(%v) = %v, expected %v", tc.path, result, tc.expected)
-                        }
-                })
-        }
-}
-
-func TestGroupWithSuffixMatching(t *testing.T) {
-        // Test critical case: group followed by suffix ($.node.(a|b).c)
-        tree := NewPatternTree()
-        
-        // Add pattern with group followed by property
-        expr, err := parser.ParseExpression("$.node.(child|value).suffix")
-        if err != nil {
-                t.Fatalf("Failed to parse group with suffix pattern: %v", err)
-        }
-        err = tree.AddPattern(expr)
-        if err != nil {
-                t.Fatalf("Failed to add group with suffix pattern: %v", err)
-        }
-        
-        // Test matching
-        testCases := []struct {
-                path     []string
-                expected bool
-                name     string
-        }{
-                {[]string{"node", "child", "suffix"}, true, "node.child.suffix should match"},
-                {[]string{"node", "value", "suffix"}, true, "node.value.suffix should match"},
-                {[]string{"node", "child"}, false, "node.child without suffix should not match"},
-                {[]string{"node", "value"}, false, "node.value without suffix should not match"},
-                {[]string{"node", "other", "suffix"}, false, "node.other.suffix should not match"},
-                {[]string{"node", "child", "wrong"}, false, "node.child.wrong should not match"},
-        }
-        
-        for _, tc := range testCases {
-                t.Run(tc.name, func(t *testing.T) {
-                        result := tree.MatchPath(tc.path)
-                        if result != tc.expected {
-                                t.Errorf("MatchPath(%v) = %v, expected %v", tc.path, result, tc.expected)
-                        }
-                })
-        }
-}
-
-func TestRepetitionWithSuffixMatching(t *testing.T) {
-        // Test critical case: repetition with suffix ($.node.(a|b){*}.c)
-        tree := NewPatternTree()
-        
-        // Add pattern with repetition followed by suffix
-        expr, err := parser.ParseExpression("$.node.(child|value){*}.suffix")
-        if err != nil {
-                t.Fatalf("Failed to parse repetition with suffix pattern: %v", err)
-        }
-        err = tree.AddPattern(expr)
-        if err != nil {
-                t.Fatalf("Failed to add repetition with suffix pattern: %v", err)
-        }
-        
-        // Test matching with different iteration counts
-        testCases := []struct {
-                path     []string
-                expected bool
-                name     string
-        }{
-                // Zero iterations (should match suffix directly)
-                {[]string{"node", "suffix"}, true, "zero iterations should match"},
-                
-                // One iteration
-                {[]string{"node", "child", "suffix"}, true, "one iteration with child should match"},
-                {[]string{"node", "value", "suffix"}, true, "one iteration with value should match"},
-                
-                // Multiple iterations
-                {[]string{"node", "child", "child", "suffix"}, true, "two child iterations should match"},
-                {[]string{"node", "value", "child", "suffix"}, true, "value then child should match"},
-                {[]string{"node", "child", "value", "child", "suffix"}, true, "multiple mixed iterations should match"},
-                
-                // Invalid cases
-                {[]string{"node", "child"}, false, "missing suffix should not match"},
-                {[]string{"node", "other", "suffix"}, false, "invalid alternative should not match"},
-                {[]string{"node", "child", "other", "suffix"}, false, "invalid iteration should not match"},
-                {[]string{"node", "child", "suffix", "extra"}, false, "extra segments should not match"},
-        }
-        
-        for _, tc := range testCases {
-                t.Run(tc.name, func(t *testing.T) {
-                        result := tree.MatchPath(tc.path)
-                        if result != tc.expected {
-                                t.Errorf("MatchPath(%v) = %v, expected %v", tc.path, result, tc.expected)
-                        }
-                })
-        }
-}
-
-func TestComplexNestedPatterns(t *testing.T) {
-        // Test the specification's complex example
-        tree := NewPatternTree()
-        
-        // Add the complex pattern from specification
-        expr, err := parser.ParseExpression("$.node.(child|meta.child){*}.value")
-        if err != nil {
-                t.Fatalf("Failed to parse complex nested pattern: %v", err)
-        }
-        err = tree.AddPattern(expr)
-        if err != nil {
-                t.Fatalf("Failed to add complex nested pattern: %v", err)
-        }
-        
-        testCases := []struct {
-                path     []string
-                expected bool
-                name     string
-        }{
-                // Zero iterations
-                {[]string{"node", "value"}, true, "direct to value should match"},
-                
-                // One iteration - simple child
-                {[]string{"node", "child", "value"}, true, "one child iteration should match"},
-                
-                // One iteration - meta.child
-                {[]string{"node", "meta", "child", "value"}, true, "one meta.child iteration should match"},
-                
-                // Multiple iterations
-                {[]string{"node", "child", "child", "value"}, true, "two child iterations should match"},
-                {[]string{"node", "meta", "child", "child", "value"}, true, "meta.child then child should match"},
-                {[]string{"node", "child", "meta", "child", "value"}, true, "child then meta.child should match"},
-                
-                // Invalid cases
-                {[]string{"node", "child"}, false, "incomplete path should not match"},
-                {[]string{"node", "meta", "value"}, false, "incomplete meta path should not match"},
-                {[]string{"node", "other", "value"}, false, "invalid alternative should not match"},
-        }
-        
-        for _, tc := range testCases {
-                t.Run(tc.name, func(t *testing.T) {
-                        result := tree.MatchPath(tc.path)
-                        if result != tc.expected {
-                                t.Errorf("MatchPath(%v) = %v, expected %v", tc.path, result, tc.expected)
-                        }
-                })
-        }
+func TestPatternTreeJSONIntegration(t *testing.T) {
+	expr, err := parser.ParseExpression("$.node.(child|meta.child){*}.value")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	tree := NewPatternTree()
+	if err := tree.AddPattern(expr); err != nil {
+		t.Fatalf("add pattern error: %v", err)
+	}
+	jsonData := `{"node":{"child":{"value":1},"meta":{"child":{"value":2}}}}`
+	processor := jsonpkg.NewPathExtractor()
+	paths, err := processor.ExtractPaths(jsonData)
+	if err != nil {
+		t.Fatalf("extract paths error: %v", err)
+	}
+	found := false
+	for _, p := range paths {
+		segments := processor.ConvertPathToSegments(p)
+		if tree.MatchSegments(segments) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected at least one matching path in JSON")
+	}
 }


### PR DESCRIPTION
## Summary
- document the schema-path grammar and extend spec types for bracket selectors, repetition nodes, and runtime path segments
- rebuild the lexer/parser and JSON segment conversion to understand wildcard, regex, and property repetition syntax
- replace the matcher with an epsilon-NFA backed trie, update the CLI to use MatchSegments, and add comprehensive parser/tree/schema tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cd80b95f3c8321b69b687ccec491cb