### PR TITLE
Use compiled jsonschema traversal for schema paths

### DIFF
--- a/cmd/schemapath/main.go
+++ b/cmd/schemapath/main.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -349,6 +351,66 @@ var extractCmd = &cobra.Command{
 	},
 }
 
+var schemaCmd = &cobra.Command{
+	Use:   "schema [schema_file]",
+	Short: "Generate all schema paths from a JSON Schema document",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		filename := args[0]
+
+		data, err := ioutil.ReadFile(filename)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading schema file %s: %v\n", filename, err)
+			os.Exit(1)
+		}
+
+		processor := jsonpkg.NewPathExtractor()
+
+		absPath, err := filepath.Abs(filename)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving schema path %s: %v\n", filename, err)
+			os.Exit(1)
+		}
+
+		schemaPath := filepath.ToSlash(absPath)
+		if !strings.HasPrefix(schemaPath, "/") {
+			schemaPath = "/" + schemaPath
+		}
+
+		schemaURL := url.URL{Scheme: "file", Path: schemaPath}
+
+		paths, err := processor.ExtractSchemaPathsWithURL(string(data), schemaURL.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error generating schema paths: %v\n", err)
+			os.Exit(1)
+		}
+
+		if outputJSON {
+			result := map[string]interface{}{
+				"file":        filename,
+				"total_paths": len(paths),
+				"paths":       paths,
+			}
+
+			var output []byte
+			if prettyPrint {
+				output, _ = json.MarshalIndent(result, "", "  ")
+			} else {
+				output, _ = json.Marshal(result)
+			}
+			fmt.Println(string(output))
+			return
+		}
+
+		if !quiet {
+			fmt.Printf("Found %d schema paths:\n", len(paths))
+		}
+		for _, path := range paths {
+			fmt.Println(path)
+		}
+	},
+}
+
 func init() {
 	// Add global flags
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
@@ -364,6 +426,7 @@ func init() {
 	rootCmd.AddCommand(testCmd)
 	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(extractCmd)
+	rootCmd.AddCommand(schemaCmd)
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/bytedance/sonic v1.14.1
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.10.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/json/processor_test.go
+++ b/json/processor_test.go
@@ -176,7 +176,7 @@ func TestExtractValue(t *testing.T) {
 	pe := NewPathExtractor()
 
 	jsonData := `{
-		"user": {
+                "user": {
 			"name": "John",
 			"contacts": [
 				{"type": "email", "value": "john@example.com"}
@@ -233,5 +233,61 @@ func TestExtractValue(t *testing.T) {
 				t.Errorf("ExtractValue(%s) = %v, expected %v", tt.path, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestExtractSchemaPaths(t *testing.T) {
+	pe := NewPathExtractor()
+
+	schema := `{
+                "type": "object",
+                "properties": {
+                        "name": {"type": "string"},
+                        "address": {
+                                "type": "object",
+                                "properties": {
+                                        "street": {"type": "string"},
+                                        "phones": {
+                                                "type": "array",
+                                                "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                                "type": {"type": "string"}
+                                                        }
+                                                }
+                                        }
+                                }
+                        }
+                }
+        }`
+
+	paths, err := pe.ExtractSchemaPaths(schema)
+	if err != nil {
+		t.Fatalf("ExtractSchemaPaths failed: %v", err)
+	}
+
+	expected := []string{
+		"$",
+		"$.address",
+		"$.address.phones",
+		"$.address.phones[*]",
+		"$.address.phones[*].type",
+		"$.address.street",
+		"$.name",
+	}
+
+	if len(paths) != len(expected) {
+		t.Fatalf("expected %d paths, got %d: %v", len(expected), len(paths), paths)
+	}
+
+	pathSet := make(map[string]bool)
+	for _, p := range paths {
+		pathSet[p] = true
+	}
+
+	for _, exp := range expected {
+		if !pathSet[exp] {
+			t.Errorf("expected schema path %s not found", exp)
+		}
 	}
 }

--- a/json/schema_paths.go
+++ b/json/schema_paths.go
@@ -1,0 +1,241 @@
+package json
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+type schemaVisitKey struct {
+	schema *jsonschema.Schema
+	path   string
+}
+
+const defaultSchemaURL = "inline.json"
+
+// ExtractSchemaPaths generates all possible schema paths from a JSON Schema document.
+// The returned paths are JSONPath-like expressions rooted at $. Object properties use
+// dot notation when possible and fall back to bracket notation with proper escaping.
+// Array items are represented using either concrete indices (for tuple validation)
+// or the wildcard form "[*]" when the schema applies to any position.
+func (pe *PathExtractor) ExtractSchemaPaths(schemaData string) ([]string, error) {
+	return pe.ExtractSchemaPathsWithURL(schemaData, defaultSchemaURL)
+}
+
+// ExtractSchemaPathsWithURL behaves like ExtractSchemaPaths but allows specifying a base URL
+// that is used when compiling the schema. This is useful when the schema contains relative $ref
+// references that should be resolved from a known location.
+func (pe *PathExtractor) ExtractSchemaPathsWithURL(schemaData, resourceURL string) ([]string, error) {
+	if resourceURL == "" {
+		resourceURL = defaultSchemaURL
+	}
+
+	compiled, err := jsonschema.CompileString(resourceURL, schemaData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile JSON schema: %w", err)
+	}
+
+	paths := make(map[string]struct{})
+	visited := make(map[schemaVisitKey]struct{})
+	stack := make(map[*jsonschema.Schema]bool)
+
+	pe.collectSchemaPaths(compiled, "$", paths, visited, stack)
+
+	result := make([]string, 0, len(paths))
+	for path := range paths {
+		result = append(result, path)
+	}
+
+	sort.Strings(result)
+	return result, nil
+}
+
+func (pe *PathExtractor) collectSchemaPaths(schema *jsonschema.Schema, currentPath string, paths map[string]struct{}, visited map[schemaVisitKey]struct{}, stack map[*jsonschema.Schema]bool) {
+	if schema == nil {
+		return
+	}
+
+	if currentPath == "" {
+		currentPath = "$"
+	}
+
+	addPath(paths, currentPath)
+
+	key := schemaVisitKey{schema: schema, path: currentPath}
+	if _, seen := visited[key]; seen {
+		return
+	}
+	visited[key] = struct{}{}
+
+	if stack[schema] {
+		return
+	}
+
+	stack[schema] = true
+	defer delete(stack, schema)
+
+	pe.collectSchemaPaths(schema.Ref, currentPath, paths, visited, stack)
+	pe.collectSchemaPaths(schema.RecursiveRef, currentPath, paths, visited, stack)
+	pe.collectSchemaPaths(schema.DynamicRef, currentPath, paths, visited, stack)
+
+	if schema.Not != nil {
+		pe.collectSchemaPaths(schema.Not, currentPath, paths, visited, stack)
+	}
+
+	for _, sub := range schema.AllOf {
+		pe.collectSchemaPaths(sub, currentPath, paths, visited, stack)
+	}
+	for _, sub := range schema.AnyOf {
+		pe.collectSchemaPaths(sub, currentPath, paths, visited, stack)
+	}
+	for _, sub := range schema.OneOf {
+		pe.collectSchemaPaths(sub, currentPath, paths, visited, stack)
+	}
+
+	if schema.If != nil {
+		pe.collectSchemaPaths(schema.If, currentPath, paths, visited, stack)
+	}
+	if schema.Then != nil {
+		pe.collectSchemaPaths(schema.Then, currentPath, paths, visited, stack)
+	}
+	if schema.Else != nil {
+		pe.collectSchemaPaths(schema.Else, currentPath, paths, visited, stack)
+	}
+
+	for name, sub := range schema.Properties {
+		childPath := currentPath + formatPropertySegment(name)
+		pe.collectSchemaPaths(sub, childPath, paths, visited, stack)
+	}
+
+	for pattern, sub := range schema.PatternProperties {
+		childPath := currentPath + "[~" + pattern.String() + "]"
+		pe.collectSchemaPaths(sub, childPath, paths, visited, stack)
+	}
+
+	switch addProps := schema.AdditionalProperties.(type) {
+	case bool:
+		if addProps {
+			addPath(paths, currentPath+"[#*]")
+		}
+	case *jsonschema.Schema:
+		pe.collectSchemaPaths(addProps, currentPath+"[#*]", paths, visited, stack)
+	}
+
+	if schema.UnevaluatedProperties != nil {
+		pe.collectSchemaPaths(schema.UnevaluatedProperties, currentPath+"[#*]", paths, visited, stack)
+	}
+
+	for _, sub := range schema.DependentSchemas {
+		pe.collectSchemaPaths(sub, currentPath, paths, visited, stack)
+	}
+
+	for _, dep := range schema.Dependencies {
+		if sub, ok := dep.(*jsonschema.Schema); ok {
+			pe.collectSchemaPaths(sub, currentPath, paths, visited, stack)
+		}
+	}
+
+	pe.expandArraySchemas(schema, currentPath, paths, visited, stack)
+}
+
+func (pe *PathExtractor) expandArraySchemas(schema *jsonschema.Schema, currentPath string, paths map[string]struct{}, visited map[schemaVisitKey]struct{}, stack map[*jsonschema.Schema]bool) {
+	for idx, sub := range schema.PrefixItems {
+		childPath := fmt.Sprintf("%s[%d]", currentPath, idx)
+		pe.collectSchemaPaths(sub, childPath, paths, visited, stack)
+	}
+
+	switch items := schema.Items.(type) {
+	case *jsonschema.Schema:
+		pe.collectSchemaPaths(items, currentPath+"[*]", paths, visited, stack)
+	case []*jsonschema.Schema:
+		for idx, sub := range items {
+			childPath := fmt.Sprintf("%s[%d]", currentPath, idx)
+			pe.collectSchemaPaths(sub, childPath, paths, visited, stack)
+		}
+	}
+
+	switch addItems := schema.AdditionalItems.(type) {
+	case bool:
+		if addItems {
+			addPath(paths, currentPath+"[*]")
+		}
+	case *jsonschema.Schema:
+		pe.collectSchemaPaths(addItems, currentPath+"[*]", paths, visited, stack)
+	}
+
+	if schema.Items2020 != nil {
+		pe.collectSchemaPaths(schema.Items2020, currentPath+"[*]", paths, visited, stack)
+	}
+
+	if schema.Contains != nil {
+		pe.collectSchemaPaths(schema.Contains, currentPath+"[*]", paths, visited, stack)
+	}
+
+	if schema.UnevaluatedItems != nil {
+		pe.collectSchemaPaths(schema.UnevaluatedItems, currentPath+"[*]", paths, visited, stack)
+	}
+
+	if hasSchemaType(schema, "array") && len(schema.PrefixItems) == 0 && schema.Items == nil && schema.Items2020 == nil && schema.Contains == nil {
+		addPath(paths, currentPath+"[*]")
+	}
+}
+
+func addPath(paths map[string]struct{}, path string) {
+	if _, exists := paths[path]; !exists {
+		paths[path] = struct{}{}
+	}
+}
+
+func hasSchemaType(schema *jsonschema.Schema, target string) bool {
+	if schema == nil {
+		return false
+	}
+	for _, t := range schema.Types {
+		if t == target {
+			return true
+		}
+	}
+	return false
+}
+
+func formatPropertySegment(name string) string {
+	if isIdentifier(name) {
+		return "." + name
+	}
+	return "[\"" + escapePropertyName(name) + "\"]"
+}
+
+func isIdentifier(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i, r := range value {
+		if i == 0 {
+			if !(r == '_' || unicode.IsLetter(r)) {
+				return false
+			}
+		} else {
+			if !(r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func escapePropertyName(value string) string {
+	if !strings.ContainsAny(value, "\\\"") {
+		return value
+	}
+	var builder strings.Builder
+	for _, r := range value {
+		if r == '\\' || r == '"' {
+			builder.WriteByte('\\')
+		}
+		builder.WriteRune(r)
+	}
+	return builder.String()
+}


### PR DESCRIPTION
## Summary
- rework the schema path extractor to compile schemas with github.com/santhosh-tekuri/jsonschema/v5 and traverse the typed structure safely
- add an alternate entry point that accepts a base URL and update the CLI schema command to resolve file URLs before generating paths
- include the jsonschema dependency in go.mod

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cdb20739a4832189fd15273b068143